### PR TITLE
Experimental Fast Simulator mode

### DIFF
--- a/.github/workflows/unittests_exp.yml
+++ b/.github/workflows/unittests_exp.yml
@@ -1,0 +1,33 @@
+name: Experimantal Unit Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{github.workspace}}/tests/unit
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        sudo apt install -y gcc-10-riscv64-linux-gnu g++-10-riscv64-linux-gnu
+        git submodule update --init ${{github.workspace}}/tests/Catch2
+        git submodule update --init ${{github.workspace}}/tests/unit/ext/lodepng
+
+    - name: Configure
+      run: cmake -B ${{github.workspace}}/build -DRISCV_EXPERIMENTAL=ON -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build the unittests
+      run: cmake --build ${{github.workspace}}/build
+
+    - name: Run tests
+      working-directory: ${{github.workspace}}/build
+      run: ctest --verbose .

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -14,6 +14,7 @@ option(RISCV_USE_RH_HASH "Enable robin-hood hashing for page tables" OFF)
 
 if (RISCV_EXPERIMENTAL)
 	option(RISCV_BINARY_TRANSLATION  "Enable binary translation" OFF)
+	option(RISCV_FAST_SIMULATOR      "Enable fast simulator mode" ON)
 endif()
 
 if (RISCV_USE_RH_HASH)
@@ -94,6 +95,9 @@ if (RISCV_EXT_A)
 endif()
 if (RISCV_EXT_C)
 	target_compile_definitions(riscv PUBLIC RISCV_EXT_COMPRESSED=1)
+	# The fast simulator is not currently working well with compressed
+	# instructions, and so we temporarily disable it until resolved.
+	set(RISCV_FAST_SIMULATOR OFF)
 endif()
 if (RISCV_EXT_F)
 	target_compile_definitions(riscv PUBLIC RISCV_EXT_FLOATS=1)
@@ -116,6 +120,18 @@ if (RISCV_BINARY_TRANSLATION)
 	target_compile_definitions(riscv PUBLIC RISCV_BINARY_TRANSLATION=1)
 	target_compile_definitions(riscv PRIVATE RISCV_TRANSLATION_CACHE=1)
 	target_link_libraries(riscv PUBLIC dl)
+	# The fast simulator is incompatible with binary translation (for now)
+	# Binary translation is so much faster that it does not matter.
+	set(RISCV_FAST_SIMULATOR OFF)
+endif()
+if (RISCV_FAST_SIMULATOR)
+	# The fast simulator is incompatible with RISCV_DEBUG because it
+	# modifies the instruction stream.
+	if (RISCV_DEBUG)
+		message(WARNING "RISCV_FAST_SIMULATOR disabled by RISCV_DEBUG")
+	else()
+		target_compile_definitions(riscv PUBLIC RISCV_FAST_SIMULATOR=1)
+	endif()
 endif()
 if (WIN32 OR MINGW_TOOLCHAIN)
 	target_link_libraries(riscv PUBLIC wsock32 ws2_32)

--- a/lib/libriscv/common.hpp
+++ b/lib/libriscv/common.hpp
@@ -75,6 +75,11 @@ namespace riscv
 #else
 	static constexpr bool binary_translation_enabled = false;
 #endif
+#ifdef RISCV_FAST_SIMULATOR
+	static constexpr bool fast_simulator_enabled = true;
+#else
+	static constexpr bool fast_simulator_enabled = false;
+#endif
 }
 
 namespace riscv
@@ -96,6 +101,9 @@ namespace riscv
 		// Instruction fusing is an experimental optimizing feature
 		// Can only be enabled with the RISCV_EXPERIMENTAL CMake option
 		bool instruction_fusing = false;
+		// Fast simulator can improve run-times, when enabled from RISCV_EXPERIMENTAL
+		// and then the RISCV_FAST_SIMULATOR CMake option. Incompatible with RISCV_DEBUG.
+		bool fast_simulator = fast_simulator_enabled;
 		// Number of workers dedicated to multiprocessing
 		unsigned multiprocessing_workers = 4;
 

--- a/lib/libriscv/decoder_cache.cpp
+++ b/lib/libriscv/decoder_cache.cpp
@@ -1,11 +1,60 @@
 #include "memory.hpp"
 #include "machine.hpp"
 #include "decoder_cache.hpp"
+#include "instruction_list.hpp"
+#ifdef RISCV_USE_RH_HASH
+#include <robin_hood.h>
+template <typename T>
+using qc_unordered_set = robin_hood::unordered_set<T>;
+#else
+#include <unordered_set>
+template <typename T>
+using qc_unordered_set = std::unordered_set<T>;
+#endif
 
 #include "rv32i_instr.hpp"
+#include "rvc.hpp"
 
 namespace riscv
 {
+	static const qc_unordered_set<uint8_t> fsim_jumpy_insn
+	{
+		RV32I_BRANCH,
+		RV32I_JALR,
+		RV32I_JAL,
+		RV32I_SYSTEM,
+	};
+	[[maybe_unused]] static constexpr size_t QC_TRESHOLD = 8;
+	[[maybe_unused]] static constexpr size_t QC_MAX = 0xFFFF;
+	[[maybe_unused]] static constexpr size_t FS_MAXI = 4096;
+
+	template <int W>
+	static bool fastsim_gucci_opcode(rv32i_instruction instr) {
+		if (instr.is_long())
+			return fsim_jumpy_insn.count(instr.opcode()) == 0;
+		const rv32c_instruction ci { instr };
+		#define CI_CODE(x, y) ((x << 13) | (y))
+		switch (ci.opcode()) {
+		case CI_CODE(0b001, 0b01):
+			if constexpr (W >= 8) return true; // C.ADDIW
+			return false; // C.JAL 32-bit
+		case CI_CODE(0b101, 0b01): // C.JMP
+		case CI_CODE(0b110, 0b01): // C.BEQZ
+		case CI_CODE(0b111, 0b01): // C.BNEZ
+			return false;
+		case CI_CODE(0b100, 0b10): { // VARIOUS
+				const bool topbit = ci.whole & (1 << 12);
+				if (!topbit && ci.CR.rd != 0 && ci.CR.rs2 == 0) {
+					return false; // C.JR rd
+				} else if (topbit && ci.CR.rd != 0 && ci.CR.rs2 == 0) {
+					return false; // C.JALR ra, rd+0
+				} // TODO: Handle C.EBREAK
+				return true;
+			}
+		default:
+			return true;
+		}
+	}
 
 #ifdef RISCV_INSTR_CACHE
 	template <int W>
@@ -29,6 +78,7 @@ namespace riscv
 #ifdef RISCV_INSTR_CACHE_PREGEN
 		auto* exec_offset = machine().cpu.exec_seg_data();
 		assert(exec_offset && "Must have set CPU execute segment");
+		auto* exec_decoder = this->m_exec_decoder;
 
 	#ifdef RISCV_BINARY_TRANSLATION
 		std::string bintr_filename;
@@ -56,14 +106,26 @@ namespace riscv
 	#endif
 
 		std::vector<typename CPU<W>::instr_pair> ipairs;
-		ipairs.reserve(len / 4);
+		if (binary_translation_enabled || options.instruction_fusing) {
+			ipairs.reserve(len / 4);
+		}
+
+#ifdef RISCV_FAST_SIMULATOR
+		size_t qc_lastidx = (options.fast_simulator) ? 0 : QC_MAX;
+		size_t qc_failure = 0;
+		rv32i_instruction qc_instr;
+		bool fs_skip = false;
+		typename CPU<W>::QCVec qcvec;
+		qcvec.base_pc = addr;
+		//static_assert(!compressed_enabled, "C-extension with fast simulator is under construction");
+#endif
 
 		/* Generate all instruction pointers for executable code.
 		   Cannot step outside of this area when pregen is enabled,
 		   so it's fine to leave the boundries alone. */
 		for (address_t dst = addr; dst < addr + len;)
 		{
-			auto& entry = m_exec_decoder[dst / DecoderCache<W>::DIVISOR];
+			auto& entry = exec_decoder[dst / DecoderCache<W>::DIVISOR];
 
 			if (binary_translation_enabled || options.instruction_fusing) {
 				// This may be a misaligned reference
@@ -75,10 +137,89 @@ namespace riscv
 				ipairs.emplace_back(entry.handler, instref);
 #endif
 			}
-			auto instruction = *(rv32i_instruction*) &exec_offset[dst];
-			DecoderCache<W>::convert(machine().cpu.decode(instruction), entry);
-			dst += (compressed_enabled) ? 2 : 4;
+
+			// Load unaligned instruction from execute segment
+			union Align32 {
+				uint16_t data[2];
+				operator uint32_t() {
+					return data[0] | uint32_t(data[1]) << 16;
+				}
+			};
+			rv32i_instruction instruction { *(Align32*) &exec_offset[dst] };
+
+			// Insert decoded instruction in decoder cache
+			auto decoded = machine().cpu.decode(instruction);
+			DecoderCache<W>::convert(decoded, entry);
+
+#ifdef RISCV_FAST_SIMULATOR
+			if (LIKELY(qc_lastidx < QC_MAX) && !fs_skip) {
+				qc_instr = instruction;
+				if (fastsim_gucci_opcode<W>(qc_instr) && qcvec.data.size() < FS_MAXI) {
+					qcvec.data.push_back({qc_instr.whole, decoded.handler});
+				} else {
+					if (qcvec.data.size()+1 >= QC_TRESHOLD) {
+						qcvec.data.push_back({qc_instr.whole, decoded.handler});
+						qcvec.end_pc = dst + qc_instr.length();
+						//printf("Fast simulator at 0x%lX, %zu good instructions\n",
+						//	(long)qcvec.base_pc, qcvec.data.size());
+						auto pc = qcvec.base_pc;
+						const size_t max = compressed_enabled ? 1 : qcvec.data.size();
+						for (size_t i = 0; i < max; i++)
+						{
+							// Write the resulting index into the instruction stream
+							auto* half = (uint16_t*) &exec_offset[pc];
+							half[0] = qc_lastidx;
+							// Set the fast simulator handler at current PC
+							auto& qc_entry = exec_decoder[pc / DecoderCache<W>::DIVISOR];
+							qc_entry.set(&CPU<W>::fast_simulator);
+							// Advance to the next accelerated instruction
+							if constexpr (compressed_enabled) {
+								const auto& idata = qcvec.data[i];
+								pc += rv32i_instruction{idata.instr}.length();
+							} else pc += 4;
+						}
+						// The outer simulator (once fast sim ends) will be
+						// trying to calculate the instruction length based
+						// on the index number written into the 16-bit
+						// instruction. To compensate, we add the real
+						// instructions length and subtract the "wrong" length.
+						const bool will_be_long = (qc_lastidx & 0x3) == 0x3;
+						qcvec.incrementor = rv32i_instruction{qcvec.data.front().instr}.length();
+						qcvec.incrementor -= will_be_long ? 4 : 2;
+						// Add the instruction data array to the CPU
+						machine().cpu.add_qc(std::move(qcvec));
+						qc_lastidx ++;
+					} else {
+						qcvec.data.clear();
+						qc_failure ++;
+					}
+					qcvec.base_pc = dst + qc_instr.length();
+				}
+			} // options.fast_simulator
+#endif
+			// Increment PC after everything
+			if constexpr (compressed_enabled) {
+				// With compressed we always step forward 2 bytes at a time
+				dst += 2;
+#ifdef RISCV_FAST_SIMULATOR
+				if (fs_skip) {
+					fs_skip = false;
+				} else if (instruction.length() == 4) {
+					// We advanced only 2 but the real instruction was 4 bytes
+					// Remember the instruction and skip one fast sim iteration
+					fs_skip = true;
+				}
+#endif
+			} else
+				dst += 4;
 		}
+
+#ifdef RISCV_FAST_SIMULATOR
+		if (options.verbose_loader) {
+			printf("Fast sim conversion blocks: %zu\n", qc_lastidx);
+			printf("Fast sim conversion failure: %zu\n", qc_failure);
+		}
+#endif
 
 		/* We do not support binary translation for RV128I */
 		/* We do not support fusing for RV128I */

--- a/lib/libriscv/decoder_cache.hpp
+++ b/lib/libriscv/decoder_cache.hpp
@@ -9,8 +9,10 @@ template <int W>
 struct DecoderData {
 #ifdef RISCV_DEBUG
 	using Handler = Instruction<W>;
+	void set(instruction_handler<W> fn) { handler.handler = fn; }
 #else
 	using Handler = instruction_handler<W>;
+	void set(instruction_handler<W> fn) { handler = fn; }
 #endif
 	Handler handler;
 };

--- a/tests/unit/heaptest.cpp
+++ b/tests/unit/heaptest.cpp
@@ -67,7 +67,7 @@ TEST_CASE("Basic heap usage", "[Heap]")
 		const int A = randInt(2, 50);
 		for (int a = 0; a < A; a++) {
 			allocs.push_back(alloc_random(arena));
-			const auto alloc = allocs.back();
+			[[maybe_unused]] const auto alloc = allocs.back();
 			HPRINT("Alloc %lX size: %4zu,  arena size: %4zu\n",
 				alloc.addr, alloc.size, arena.size(alloc.addr));
 		}

--- a/tests/unit/run_experimentally.sh
+++ b/tests/unit/run_experimentally.sh
@@ -1,0 +1,9 @@
+FOLDER=build_unittests_exp
+set -e
+
+mkdir -p $FOLDER
+pushd $FOLDER
+cmake .. -DCMAKE_BUILD_TYPE=Debug -DRISCV_EXPERIMENTAL=ON
+make -j6
+ctest --verbose .
+popd


### PR DESCRIPTION
This mode tries to create sequential runnable sequences that can be run extremely fast, while certain conditions are true.
This mode is 25-33% faster than the second fastest mode, and although not close to binary translation, it is 2x faster than the simulator with the instruction cache disabled.