### PR TITLE
Use real instruction count to avoid exiting binary translation loops

### DIFF
--- a/lib/libriscv/machine.hpp
+++ b/lib/libriscv/machine.hpp
@@ -243,6 +243,7 @@ namespace riscv
 		// Returns true if the Machine has loaded native code
 		// generated from binary translation.
 		bool is_binary_translated() const { return memory.is_binary_translated(); }
+		std::pair<uint64_t&, uint64_t&> get_counters() noexcept { return {m_counter, m_max_counter}; }
 
 		// Serializes all the machine state + a tiny header to @vec
 		void serialize_to(std::vector<uint8_t>& vec) const;

--- a/lib/libriscv/rvi_instr.cpp
+++ b/lib/libriscv/rvi_instr.cpp
@@ -527,6 +527,7 @@ namespace riscv
 				dst = (src1 >> shift) | (src1 << (RVXLEN(cpu) - shift));
 				return;
 			}
+			break;
 		case 0x6: // OR
 			dst = src1 | src2;
 			return;

--- a/lib/libriscv/tr_api.cpp
+++ b/lib/libriscv/tr_api.cpp
@@ -73,6 +73,8 @@ static struct CallbackTable {
 	float  (*sqrtf32)(float);
 	double (*sqrtf64)(double);
 } api;
+static uint64_t* cur_insn;
+static uint64_t* max_insn;
 
 void* memcpy(void * restrict dst, const void * restrict src, unsigned len)
 {
@@ -107,8 +109,10 @@ static inline uint64_t MUL128(
 	return (middle << 32) | (uint32_t)p00;
 }
 
-extern void init(struct CallbackTable* table) {
+extern void init(struct CallbackTable* table, uint64_t* cur_icount, uint64_t* max_icount) {
 	api = *table;
+	cur_insn = cur_icount;
+	max_insn = max_icount;
 };
 )123";
 }

--- a/lib/libriscv/tr_api.hpp
+++ b/lib/libriscv/tr_api.hpp
@@ -12,6 +12,7 @@ namespace riscv {
 		void (*mem_write16)(CPU<W>&, address_type<W> addr, uint16_t);
 		void (*mem_write32)(CPU<W>&, address_type<W> addr, uint32_t);
 		void (*mem_write64)(CPU<W>&, address_type<W> addr, uint64_t);
+		uint64_t max_instr(CPU<W>&);
 		void (*jump)(CPU<W>&, address_type<W>, uint64_t);
 		void (*finish)(CPU<W>&, address_type<W>, uint64_t);
 		int  (*syscall)(CPU<W>&, address_type<W>, uint64_t);

--- a/lib/libriscv/tr_types.hpp
+++ b/lib/libriscv/tr_types.hpp
@@ -1,0 +1,19 @@
+#include "types.hpp"
+#include <set>
+
+namespace riscv
+{
+	template <int W>
+	struct TransInfo
+	{
+		address_type<W> basepc;
+		address_type<W> gp;
+		int len;
+		bool has_branch;
+		bool forward_jumps;
+		std::set<address_type<W>> jump_locations;
+	};
+
+	template <int W>
+	struct TransInstr;
+}

--- a/lib/libriscv/types.hpp
+++ b/lib/libriscv/types.hpp
@@ -3,7 +3,6 @@
 #include <cstdint>
 #include <exception>
 #include <type_traits>
-#include <set>
 
 namespace riscv
 {
@@ -87,17 +86,11 @@ namespace riscv
 	};
 
 	template <int W>
-	struct TransInfo {
-		address_type<W> basepc;
-		address_type<W> gp;
-		int len;
-		bool has_branch;
-		bool forward_jumps;
-		std::set<address_type<W>> jump_locations;
-	};
+	struct TransInfo;
 
 	template <int W>
-	struct TransInstr {
+	struct TransInstr
+	{
 		uint32_t instr;
 	};
 }


### PR DESCRIPTION
Binary translation improvements that aims to improve performance and B-extension support

C-extension is still out of the question, but it would be nice to support the already supported B-extension instructions in order to avoid weird simulation bugs. It has always been the case that binary translation has been a little bit wonky, but it is now starting to feel robust and reliable. Already running the DOOM example at less CPU% than regular interpreter.
