### PR TITLE
Pass instruction counters in registers to simulate()

### DIFF
--- a/docs/VMCALL.md
+++ b/docs/VMCALL.md
@@ -127,13 +127,15 @@ auto test_addr = machine.address_of("test");
 
 // Reset the stack pointer from any previous call to its initial value
 machine.cpu.reset_stack_pointer();
+// Reset the instruction counter, as the resume() function will only increment it
+machine.reset_instruction_counter();
 // Function call setup for the guest VM, but don't start execution
 machine.setup_call(test_addr, 555, 666);
 // Run the program for X amount of instructions, then print something, then
 // resume execution again. Do this until stopped.
 do {
-	// Execute 1000 instructions at a time
-	machine.simulate<false>(1000);
+	// Execute 1000 instructions at a time without resetting the counter
+	machine.resume<false>(1000);
 	// Do some work in between simulation
 	printf("Working ...\n");
 } while (machine.instruction_limit_reached());

--- a/examples/doom/src/main.cpp
+++ b/examples/doom/src/main.cpp
@@ -262,7 +262,11 @@ int main(int argc, char *argv[])
 
 	try {
 		do {
-			machine.simulate();
+			// Resume simulation:
+			// Keep the instruction counter value without resetting it,
+			// by instead setting the max counter relative to the
+			// current instruction counter.
+			machine.resume(50'000'000ull);
 
 			// Statistics performed outside of simulation
 			if (stats.restarting) {

--- a/lib/libriscv/cpu.hpp
+++ b/lib/libriscv/cpu.hpp
@@ -36,7 +36,7 @@ namespace riscv
 		// 3. TCO: Uses musttail to jump around at the fastest speed, but
 		// is only supported on Clang. Fastest simulation.
 		// Executes using the default-selected simulation mode.
-		void simulate();
+		void simulate(uint64_t icounter, uint64_t maxcounter);
 
 		// Step precisely one instruction forward.
 		void step_one();

--- a/lib/libriscv/cpu_dispatch.cpp
+++ b/lib/libriscv/cpu_dispatch.cpp
@@ -77,7 +77,7 @@ namespace riscv
 
 
 template <int W> DISPATCH_ATTR
-void CPU<W>::simulate()
+void CPU<W>::simulate(uint64_t inscounter, uint64_t maxcounter)
 {
 	static constexpr uint32_t XLEN = W * 8;
 	using addr_t  = address_type<W>;
@@ -204,12 +204,12 @@ void CPU<W>::simulate()
 	};
 #endif
 
+	InstrCounter counter{machine(), inscounter, maxcounter};
+
 	DecodedExecuteSegment<W>* exec = this->m_exec;
 	address_t current_begin = exec->exec_begin();
 	address_t current_end = exec->exec_end();
 	address_t pc = this->pc();
-
-	InstrCounter counter{machine()};
 
 	DecoderData<W>* exec_decoder = exec->decoder_cache();
 	DecoderData<W>* decoder;
@@ -297,7 +297,7 @@ INSTRUCTION(RV32I_BC_SYSCALL, rv32i_syscall) {
 	// Make the current PC visible
 	this->registers().pc = pc;
 	// Make the instruction counter(s) visible
-	counter.apply_counter();
+	counter.apply();
 	// Invoke system call
 	machine().system_call(this->reg(REG_ECALL));
 	// Restore max counter
@@ -374,7 +374,7 @@ INSTRUCTION(RV32I_BC_SYSTEM, rv32i_system) {
 	// Make the current PC visible
 	this->registers().pc = pc;
 	// Make the instruction counter visible
-	counter.apply_counter();
+	counter.apply();
 	// Invoke SYSTEM
 	machine().system(instr);
 	// Restore PC in case it changed (supervisor)

--- a/lib/libriscv/instruction_counter.hpp
+++ b/lib/libriscv/instruction_counter.hpp
@@ -9,10 +9,10 @@ namespace riscv
 	// When binary translation is enabled we cannot do this optimization.
 	template <int W>
 	struct InstrCounter {
-		InstrCounter(Machine<W>& m)
+		InstrCounter(Machine<W>& m, uint64_t icounter, uint64_t maxcounter)
 		  : machine(m),
-		    m_counter(m.instruction_counter()),
-			m_max(m.max_instructions())
+		    m_counter(icounter),
+			m_max(maxcounter)
 		{}
 		~InstrCounter() {
 			machine.set_instruction_counter(m_counter);

--- a/lib/libriscv/machine.hpp
+++ b/lib/libriscv/machine.hpp
@@ -54,7 +54,7 @@ namespace riscv
 		// the machine will throw a MachineTimeoutException if it hits the
 		// given instruction limit.
 		template <bool Throw = true>
-		void simulate(uint64_t max_instructions = UINT64_MAX);
+		void simulate(uint64_t max_instructions = UINT64_MAX, uint64_t counter = 0u);
 
 		// Sets the machines max instructions counter to zero, which effectively
 		// causes the machine to stop. instruction_limit_reached() will return

--- a/lib/libriscv/machine_inline.hpp
+++ b/lib/libriscv/machine_inline.hpp
@@ -38,6 +38,13 @@ inline void Machine<W>::simulate(uint64_t max_instr, uint64_t counter)
 }
 
 template <int W>
+template <bool Throw>
+inline void Machine<W>::resume(uint64_t max_instr)
+{
+	this->simulate(this->instruction_counter() + max_instr, this->instruction_counter());
+}
+
+template <int W>
 inline void Machine<W>::reset()
 {
 	cpu.reset();

--- a/lib/libriscv/machine_inline.hpp
+++ b/lib/libriscv/machine_inline.hpp
@@ -23,15 +23,12 @@ void Machine<W>::penalize(uint64_t val) noexcept
 
 template <int W>
 template <bool Throw>
-inline void Machine<W>::simulate(uint64_t max_instr)
+inline void Machine<W>::simulate(uint64_t max_instr, uint64_t counter)
 {
-	// Calculate the instruction limit
-	if (max_instr != UINT64_MAX)
-		this->set_max_instructions(this->instruction_counter() + max_instr);
-	else
-		this->set_max_instructions(UINT64_MAX);
+	this->set_max_instructions(max_instr);
 
-	cpu.simulate();
+	cpu.simulate(counter, max_instr);
+
 	if constexpr (Throw) {
 		// It is a timeout exception if the max counter is non-zero and
 		// the simulation ended. Otherwise, the machine stopped normally.

--- a/tests/unit/micro.cpp
+++ b/tests/unit/micro.cpp
@@ -47,17 +47,16 @@ TEST_CASE("Run exactly X instructions", "[Micro]")
 	// Reset CPU registers and counter
 	machine.cpu.registers() = {};
 	machine.cpu.jump(dst);
-	machine.reset_instruction_counter();
 
 	// Normal simulation
-	machine.simulate<false>(2);
+	machine.simulate<false>(2, 0u);
 	REQUIRE(machine.instruction_counter() == 3);
 	REQUIRE(machine.cpu.reg(REG_ARG7) == 93);
 
 	machine.cpu.reg(REG_ARG7) = 0;
 
-	machine.simulate<false>(2);
-	REQUIRE((machine.instruction_counter() == 5 || machine.instruction_counter() == 6));
+	machine.simulate<false>(2, machine.instruction_counter());
+	REQUIRE(machine.instruction_counter() == 5);
 	REQUIRE(machine.cpu.reg(REG_ARG7) == 93);
 }
 


### PR DESCRIPTION
This is in an effort to reduce the load on the simulate() function at the beginning, but no noticable improvement. Also, added a resume() function and made preempt() instruction counting more explicit.
