### PR TITLE
Don't store the max counter when timeout exception enabled

### DIFF
--- a/lib/libriscv/cpu.hpp
+++ b/lib/libriscv/cpu.hpp
@@ -29,6 +29,10 @@ namespace riscv
 		// which is the same as the machine stopping normally, or by
 		// reaching the instruction limit, running out of instructions.
 		//
+		// The function returns the current maximum limit after simulation ended.
+		// If the limit is 0, then the machine was stopped normally, otherwise
+		// the instruction count limit was reached.
+		//
 		// 1. Bytecode: Executes one block at a time, and can only stop when the
 		// block ends or a system call is handled. Works and runs everywhere.
 		// 2. Threaded: Uses computed gotos to jump around at a faster speed, but
@@ -36,7 +40,7 @@ namespace riscv
 		// 3. TCO: Uses musttail to jump around at the fastest speed, but
 		// is only supported on Clang. Fastest simulation.
 		// Executes using the default-selected simulation mode.
-		bool simulate(uint64_t icounter, uint64_t maxcounter);
+		uint64_t simulate(uint64_t icounter, uint64_t maxcounter);
 
 		// Step precisely one instruction forward.
 		void step_one();

--- a/lib/libriscv/cpu_dispatch.cpp
+++ b/lib/libriscv/cpu_dispatch.cpp
@@ -77,7 +77,7 @@ namespace riscv
 
 
 template <int W> DISPATCH_ATTR
-bool CPU<W>::simulate(uint64_t inscounter, uint64_t maxcounter)
+uint64_t CPU<W>::simulate(uint64_t inscounter, uint64_t maxcounter)
 {
 	static constexpr uint32_t XLEN = W * 8;
 	using addr_t  = address_type<W>;
@@ -332,8 +332,7 @@ INSTRUCTION(RV32I_BC_FUNCTION, execute_decoded_function) {
 }
 INSTRUCTION(RV32I_BC_STOP, rv32i_stop) {
 	REGISTERS().pc = pc + 4;
-	counter.stop();
-	return true;
+	return 0;
 }
 
 INSTRUCTION(RV32I_BC_JAL, rv32i_jal) {
@@ -438,7 +437,7 @@ counter_overflow:
 	registers().pc = pc;
 
 	// Machine stopped normally?
-	return counter.max() == 0;
+	return counter.max();
 
 } // CPU::simulate_XXX()
 

--- a/lib/libriscv/machine.hpp
+++ b/lib/libriscv/machine.hpp
@@ -270,7 +270,7 @@ namespace riscv
 		template<typename... Args, std::size_t... indices>
 		auto resolve_args(std::index_sequence<indices...>) const;
 		static void setup_native_heap_internal(const size_t);
-		void timeout_exception(uint64_t);
+		[[noreturn]] void timeout_exception(uint64_t);
 
 		uint64_t     m_counter = 0;
 		uint64_t     m_max_counter = 0;

--- a/lib/libriscv/machine_inline.hpp
+++ b/lib/libriscv/machine_inline.hpp
@@ -25,15 +25,18 @@ template <int W>
 template <bool Throw>
 inline bool Machine<W>::simulate(uint64_t max_instr, uint64_t counter)
 {
-	this->set_max_instructions(max_instr);
-
-	const bool stopped = cpu.simulate(counter, max_instr);
+	const auto new_max = cpu.simulate(counter, max_instr);
 	if constexpr (Throw) {
-		if (!stopped)
+		// The simulation ends normally (new_max == 0), or it throws an exception
+		// Storing to m_max_counter is not helpful here.
+		if (UNLIKELY(new_max))
 			timeout_exception(max_instr);
+		return false;
+	} else {
+		// Here m_max_counter is useful for instruction_limit_reached() and stopped().
+		this->m_max_counter = new_max;
+		return new_max == 0;
 	}
-
-	return stopped;
 }
 
 template <int W>

--- a/lib/libriscv/tailcall_dispatch.cpp
+++ b/lib/libriscv/tailcall_dispatch.cpp
@@ -414,7 +414,7 @@ namespace riscv
 	}
 
 	template <int W> inline RISCV_HOT_PATH()
-	bool CPU<W>::simulate(uint64_t inscounter, uint64_t maxcounter)
+	uint64_t CPU<W>::simulate(uint64_t inscounter, uint64_t maxcounter)
 	{
 		// We need an execute segment matching current PC
 		if (UNLIKELY(!is_executable(this->pc())))
@@ -438,7 +438,7 @@ namespace riscv
 		cpu.registers().pc = new_pc;
 
 		// Machine stopped normally?
-		return counter.max() == 0;
+		return counter.max();
 
 	} // CPU::simulate_tco()
 


### PR DESCRIPTION
It's probably risky to return two values from dispatch, but we take that chance because we no longer have to store the max counter in most cases.
