### PR TITLE
Use registers for counters when entering and leaving binary translation

### DIFF
--- a/lib/libriscv/cpu_dispatch.cpp
+++ b/lib/libriscv/cpu_dispatch.cpp
@@ -354,12 +354,10 @@ INSTRUCTION(RV32I_BC_TRANSLATOR, translated_function) {
 	VIEW_INSTR();
 	// Make the current PC visible
 	this->registers().pc = pc;
-	// Make the instruction counters visible
-	counter.apply_counter_minus_1();
 	// Invoke translated code
-	exec->mapping_at(instr.whole)(*this, instr);
-	// Restore all counters
-	counter.retrieve();
+	auto new_counters = 
+		exec->mapping_at(instr.whole)(*this, counter.value()-1, counter.max());
+	counter.set_counters(new_counters.counter, new_counters.max_counter);
 	// Translations always execute at least a block
 	pc = registers().pc;
 	goto check_jump;
@@ -372,7 +370,7 @@ INSTRUCTION(RV32I_BC_SYSTEM, rv32i_system) {
 	VIEW_INSTR();
 	// Make the current PC visible
 	this->registers().pc = pc;
-	// Make the instruction counter visible
+	// Make the instruction counters visible
 	counter.apply();
 	// Invoke SYSTEM
 	machine().system(instr);

--- a/lib/libriscv/cpu_dispatch.cpp
+++ b/lib/libriscv/cpu_dispatch.cpp
@@ -355,9 +355,9 @@ INSTRUCTION(RV32I_BC_TRANSLATOR, translated_function) {
 	// Make the current PC visible
 	this->registers().pc = pc;
 	// Invoke translated code
-	auto new_counters = 
+	auto bintr_results = 
 		exec->mapping_at(instr.whole)(*this, counter.value()-1, counter.max());
-	counter.set_counters(new_counters.counter, new_counters.max_counter);
+	counter.set_counters(bintr_results.counter, bintr_results.max_counter);
 	// Translations always execute at least a block
 	pc = registers().pc;
 	goto check_jump;

--- a/lib/libriscv/cpu_dispatch.cpp
+++ b/lib/libriscv/cpu_dispatch.cpp
@@ -352,11 +352,9 @@ INSTRUCTION(RV32I_BC_JAL, rv32i_jal) {
 INSTRUCTION(RV32I_BC_TRANSLATOR, translated_function) {
 #ifdef RISCV_BINARY_TRANSLATION
 	VIEW_INSTR();
-	// Make the current PC visible
-	this->registers().pc = pc;
 	// Invoke translated code
 	auto bintr_results = 
-		exec->mapping_at(instr.whole)(*this, counter.value()-1, counter.max());
+		exec->unchecked_mapping_at(instr.whole)(*this, counter.value()-1, counter.max(), pc);
 	counter.set_counters(bintr_results.counter, bintr_results.max_counter);
 	// Translations always execute at least a block
 	pc = registers().pc;

--- a/lib/libriscv/decoded_exec_segment.hpp
+++ b/lib/libriscv/decoded_exec_segment.hpp
@@ -61,6 +61,7 @@ namespace riscv
 		void reserve_mappings(size_t mappings) { m_translator_mappings.reserve(mappings); }
 		void add_mapping(bintr_block_func<W> handler) { m_translator_mappings.push_back(handler); }
 		bintr_block_func<W> mapping_at(unsigned i) const { return m_translator_mappings.at(i); }
+		bintr_block_func<W> unchecked_mapping_at(unsigned i) const { return m_translator_mappings.at(i); }
 #else
 		bool is_binary_translated() const noexcept { return false; }
 #endif

--- a/lib/libriscv/decoded_exec_segment.hpp
+++ b/lib/libriscv/decoded_exec_segment.hpp
@@ -59,8 +59,8 @@ namespace riscv
 		bool is_binary_translated() const noexcept { return m_bintr_dl != nullptr; }
 		void set_binary_translated(void* dl) const { m_bintr_dl = dl; }
 		void reserve_mappings(size_t mappings) { m_translator_mappings.reserve(mappings); }
-		void add_mapping(instruction_handler<W> handler) { m_translator_mappings.push_back(handler); }
-		instruction_handler<W> mapping_at(unsigned i) const { return m_translator_mappings.at(i); }
+		void add_mapping(bintr_block_func<W> handler) { m_translator_mappings.push_back(handler); }
+		bintr_block_func<W> mapping_at(unsigned i) const { return m_translator_mappings.at(i); }
 #else
 		bool is_binary_translated() const noexcept { return false; }
 #endif
@@ -84,7 +84,7 @@ namespace riscv
 		std::unique_ptr<DecoderCache<W>[]> m_decoder_cache = nullptr;
 
 #ifdef RISCV_BINARY_TRANSLATION
-		std::vector<instruction_handler<W>> m_translator_mappings;
+		std::vector<bintr_block_func<W>> m_translator_mappings;
 		mutable void* m_bintr_dl = nullptr;
 #endif
 	};

--- a/lib/libriscv/instruction_counter.hpp
+++ b/lib/libriscv/instruction_counter.hpp
@@ -47,8 +47,9 @@ namespace riscv
 		void stop() noexcept {
 			m_max = 0; // This stops the machine
 		}
-		void set_counter(uint64_t value) {
+		void set_counters(uint64_t value, uint64_t max) {
 			m_counter = value;
+			m_max     = max;
 		}
 		void increment_counter(uint64_t cnt) {
 			m_counter += cnt;

--- a/lib/libriscv/tailcall_dispatch.cpp
+++ b/lib/libriscv/tailcall_dispatch.cpp
@@ -264,12 +264,12 @@ namespace riscv
 #ifdef RISCV_BINARY_TRANSLATION
 		VIEW_INSTR();
 		// Make the current PC visible
-		cpu.registers().pc = pc;
+		REGISTERS().pc = pc;
 		auto new_counters = 
-			exec->mapping_at(instr.whole)(*this, counter.value()-1, counter.max());
+			exec->mapping_at(instr.whole)(CPU(), counter.value()-1, counter.max());
 		counter.set_counters(new_counters.counter, new_counters.max_counter);
 		// Translations are always full-length instructions (?)
-		pc = cpu.registers().pc;
+		pc = REGISTERS().pc;
 		OVERFLOW_CHECK();
 		UNCHECKED_JUMP();
 #else

--- a/lib/libriscv/tailcall_dispatch.cpp
+++ b/lib/libriscv/tailcall_dispatch.cpp
@@ -265,14 +265,11 @@ namespace riscv
 		VIEW_INSTR();
 		// Make the current PC visible
 		cpu.registers().pc = pc;
-		// Make the instruction counter visible
-		counter.apply_counter_minus_1();
-		// Invoke translated code
-		exec->mapping_at(instr.whole)(cpu, instr);
-		// Restore counter
-		counter.retrieve();
+		auto new_counters = 
+			exec->mapping_at(instr.whole)(*this, counter.value()-1, counter.max());
+		counter.set_counters(new_counters.counter, new_counters.max_counter);
 		// Translations are always full-length instructions (?)
-		pc = cpu.registers().pc + 4;
+		pc = cpu.registers().pc;
 		OVERFLOW_CHECK();
 		UNCHECKED_JUMP();
 #else

--- a/lib/libriscv/tailcall_dispatch.cpp
+++ b/lib/libriscv/tailcall_dispatch.cpp
@@ -263,8 +263,6 @@ namespace riscv
 	INSTRUCTION(RV32I_BC_TRANSLATOR, translated_function) {
 #ifdef RISCV_BINARY_TRANSLATION
 		VIEW_INSTR();
-		// Make the current PC visible
-		REGISTERS().pc = pc;
 		auto new_counters = 
 			exec->mapping_at(instr.whole)(CPU(), counter.value()-1, counter.max());
 		counter.set_counters(new_counters.counter, new_counters.max_counter);

--- a/lib/libriscv/tr_api.cpp
+++ b/lib/libriscv/tr_api.cpp
@@ -150,7 +150,7 @@ static const addr_t ARENA_WRITE_BOUNDARY = RISCV_ARENA_END - RISCV_ARENA_ROEND;
 #define ARENA_READABLE(x) ((x) - 0x1000 < ARENA_READ_BOUNDARY)
 #define ARENA_WRITABLE(x) ((x) - RISCV_ARENA_ROEND < ARENA_WRITE_BOUNDARY)
 
-static inline int do_syscall(CPU* cpu, addr_t sysno, uint64_t counter, uint64_t max_counter)
+static inline int do_syscall(CPU* cpu, uint64_t counter, uint64_t max_counter, addr_t sysno)
 {
 	*cur_insn = counter; // Reveal instruction counters
 	*max_insn = max_counter;

--- a/lib/libriscv/tr_api.cpp
+++ b/lib/libriscv/tr_api.cpp
@@ -159,8 +159,8 @@ static inline int do_syscall(CPU* cpu, uint64_t counter, uint64_t max_counter, a
 		api.syscalls[SPECSAFE(sysno)](cpu);
 	else
 		api.unknown_syscall(cpu, sysno);
-	// if the system call did not modify PC, return to bintr
-	return !(cpu->pc == old_pc && counter < *max_insn);
+	// Resume if the system call did not modify PC, or hit a limit
+	return (cpu->pc != old_pc || counter >= *max_insn);
 }
 
 static inline void jump(CPU* cpu, addr_t addr) {

--- a/lib/libriscv/tr_api.cpp
+++ b/lib/libriscv/tr_api.cpp
@@ -150,15 +150,17 @@ static const addr_t ARENA_WRITE_BOUNDARY = RISCV_ARENA_END - RISCV_ARENA_ROEND;
 #define ARENA_READABLE(x) ((x) - 0x1000 < ARENA_READ_BOUNDARY)
 #define ARENA_WRITABLE(x) ((x) - RISCV_ARENA_ROEND < ARENA_WRITE_BOUNDARY)
 
-static inline int do_syscall(CPU* cpu, addr_t sysno)
+static inline int do_syscall(CPU* cpu, addr_t sysno, uint64_t counter, uint64_t max_counter)
 {
+	*cur_insn = counter; // Reveal instruction counters
+	*max_insn = max_counter;
 	addr_t old_pc = cpu->pc;
 	if (LIKELY(sysno < RISCV_MAX_SYSCALLS))
 		api.syscalls[SPECSAFE(sysno)](cpu);
 	else
 		api.unknown_syscall(cpu, sysno);
 	// if the system call did not modify PC, return to bintr
-	return !(cpu->pc == old_pc && *cur_insn < *max_insn);
+	return !(cpu->pc == old_pc && counter < *max_insn);
 }
 
 static inline void jump(CPU* cpu, addr_t addr) {
@@ -202,5 +204,10 @@ extern void init(struct CallbackTable* table,
 	cur_insn = cur_icount;
 	max_insn = max_icount;
 };
+
+typedef struct {
+	uint64_t counter;
+	uint64_t max_counter;
+} ReturnValues;
 )123";
 }

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -320,8 +320,12 @@ inline void Emitter<W>::add_branch(const BranchInfo& binfo, const std::string& o
 		// this is a jump back to the start of the function
 		code += "if (" + LOOP_EXPRESSION + ") goto " + func + "_start;\n";
 	} else if (binfo.jump_pc != 0) {
-		// forward jump to label (from absolute index)
-		code += "if (" + LOOP_EXPRESSION + ") goto " + FUNCLABEL(binfo.jump_pc) + ";\n";
+		if (binfo.jump_pc > this->pc())
+			// forward jump
+			code += "goto " + FUNCLABEL(binfo.jump_pc) + ";\n";
+		else
+			// backward jump
+			code += "if (" + LOOP_EXPRESSION + ") goto " + FUNCLABEL(binfo.jump_pc) + ";\n";
 	}
 	// else, exit binary translation
 	// The number of instructions to increment depends on if branch-instruction-counting is enabled

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1293,12 +1293,12 @@ CPU<W>::emit(std::string& code, const TransInfo<W>& tinfo) const
 	e.emit();
 
 	// Function header
-	code += "static ReturnValues " + e.get_func() + "(CPU* cpu, uint64_t counter, uint64_t max_counter) {\n";
+	code += "static ReturnValues " + e.get_func() + "(CPU* cpu, uint64_t counter, uint64_t max_counter, addr_t pc) {\n";
 
 	// Extra function entries
 	if (e.get_mappings().size() > 1)
 	{
-		code += "switch (cpu->pc) {\n";
+		code += "switch (pc) {\n";
 		code += "case " + std::to_string(tinfo.basepc) + ": goto " + e.get_func() + "_start;\n";
 		for (size_t idx = 1; idx < e.get_mappings().size(); idx++) {
 			auto& entry = e.get_mappings().at(idx);

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -258,7 +258,7 @@ if constexpr (SCAN_FOR_GP) {
 	code += R"V0G0N(
 struct Mapping {
 	addr_t addr;
-	ReturnValues (*handler)(CPU*, uint64_t, uint64_t);
+	ReturnValues (*handler)(CPU*, uint64_t, uint64_t, addr_t);
 };
 const struct Mapping mappings[] = {
 )V0G0N";

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -258,7 +258,7 @@ if constexpr (SCAN_FOR_GP) {
 	code += R"V0G0N(
 struct Mapping {
 	addr_t addr;
-	void (*handler)();
+	ReturnValues (*handler)(CPU*, uint64_t, uint64_t);
 };
 const struct Mapping mappings[] = {
 )V0G0N";
@@ -413,7 +413,7 @@ void CPU<W>::activate_dylib(DecodedExecuteSegment<W>& exec, void* dylib) const
 	uint32_t* no_mappings = (uint32_t *)dylib_lookup(dylib, "no_mappings");
 	struct Mapping {
 		address_t addr;
-		instruction_handler<W> handler;
+		bintr_block_func<W> handler;
 	};
 	Mapping* mappings = (Mapping *)dylib_lookup(dylib, "mappings");
 

--- a/lib/libriscv/types.hpp
+++ b/lib/libriscv/types.hpp
@@ -102,6 +102,6 @@ namespace riscv
 		uint64_t max_counter;
 	};
 	template <int W>
-	using bintr_block_func = bintr_block_returns (*)(CPU<W>&, uint64_t, uint64_t);
+	using bintr_block_func = bintr_block_returns (*)(CPU<W>&, uint64_t, uint64_t, address_type<W>);
 #endif
 }

--- a/lib/libriscv/types.hpp
+++ b/lib/libriscv/types.hpp
@@ -4,6 +4,7 @@
 #include <exception>
 #include <string>
 #include <type_traits>
+#include "libriscv_settings.h"
 
 namespace riscv
 {
@@ -86,6 +87,7 @@ namespace riscv
 		TRAP_EXEC  = 0x2000,
 	};
 
+#ifdef RISCV_BINARY_TRANSLATION
 	template <int W>
 	struct TransInfo;
 
@@ -94,4 +96,12 @@ namespace riscv
 		address_type<W> addr;
 		std::string     symbol;
 	};
+
+	struct bintr_block_returns {
+		uint64_t counter;
+		uint64_t max_counter;
+	};
+	template <int W>
+	using bintr_block_func = bintr_block_returns (*)(CPU<W>&, uint64_t, uint64_t);
+#endif
 }


### PR DESCRIPTION
The brutal tests will not pass with binary translation with the first two commits, as something is desynched.
