### PR TITLE
Use a set of global jumps to get more function entry mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Non goals:
 
 ## Benchmarks
 
-[STREAM memory benchmark](https://gist.github.com/fwsGonzo/a594727a9429cb29f2012652ad43fb37) [CoreMark: 7841](https://gist.github.com/fwsGonzo/7ef100ba4fe7116e97ddb20cf26e6879) vs 41382 native.
+[STREAM benchmark](https://gist.github.com/fwsGonzo/a594727a9429cb29f2012652ad43fb37) [CoreMark: 12601](https://gist.github.com/fwsGonzo/7ef100ba4fe7116e97ddb20cf26e6879) vs 41382 native.
 
 Run [D00M 1 in libriscv](/examples/doom) and see for yourself. It should use around 8% CPU at 60 fps.
 

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -343,8 +343,8 @@ void Emitter<W>::emit()
 		this->instr = tinfo.instr[i];
 		this->m_pc = tinfo.basepc + i * 4;
 
-		// known jump locations
-		if (mapping_labels.count(i)) {
+		// If the address is a return address or a global JAL target
+		if (i > 0 && (mapping_labels.count(i) || tinfo.global_jump_locations.count(this->pc()))) {
 			this->increment_counter_so_far();
 			// Re-entry through the current function
 			code.append(FUNCLABEL(this->pc()) + ":;\n");
@@ -352,6 +352,7 @@ void Emitter<W>::emit()
 				this->pc(), this->func
 			});
 		}
+		// known jump locations
 		else if (tinfo.jump_locations.count(this->pc()) || labels.count(i)) {
 			this->increment_counter_so_far();
 			code.append(FUNCLABEL(this->pc()) + ":;\n");

--- a/lib/libriscv/tr_types.hpp
+++ b/lib/libriscv/tr_types.hpp
@@ -1,6 +1,6 @@
 #include "types.hpp"
 #include "rv32i_instr.hpp"
-#include <set>
+#include <unordered_set>
 
 namespace riscv
 {
@@ -16,8 +16,10 @@ namespace riscv
 		address_type<W> gp;
 		int len;
 		bool forward_jumps;
-		std::set<address_type<W>> jump_locations;
+		std::unordered_set<address_type<W>> jump_locations;
 		// Pointer to all the other blocks (including current)
 		std::vector<TransInfo<W>>* blocks = nullptr;
+
+		std::unordered_set<address_type<W>>& global_jump_locations;
 	};
 }


### PR DESCRIPTION
This tiny change increases CoreMark score to 12.6k, ~33% of native performance