### PR TITLE
UBsan dispatch only for fuzzing and sanitizer mode

### DIFF
--- a/lib/libriscv/bytecode_dispatch.cpp
+++ b/lib/libriscv/bytecode_dispatch.cpp
@@ -1,6 +1,5 @@
 #include "common.hpp"
 #define DISPATCH_MODE_SWITCH_BASED
-#define DISPATCH_ATTR RISCV_HOT_PATH()
 #define DISPATCH_FUNC simulate_bytecode
 
 #define EXECUTE_INSTR() \

--- a/lib/libriscv/cpu_dispatch.cpp
+++ b/lib/libriscv/cpu_dispatch.cpp
@@ -22,6 +22,7 @@ namespace riscv
 {
 	static constexpr bool VERBOSE_JUMPS = riscv::verbose_branches_enabled;
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#warning "The emulator is currently built with sanitizer and fuzzing mode enabled"
 	static constexpr bool FUZZING = true;
 #else
 	static constexpr bool FUZZING = false;
@@ -75,6 +76,14 @@ namespace riscv
 #define OVERFLOW_CHECKED_JUMP() \
 	goto check_jump
 
+// We will not use the undefined sanitizer outside of
+// sanitizing and fuzzing modes. Sanitizers are not effective
+// anyway without defining FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION.
+#if defined(__GNUG__) && !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
+#define DISPATCH_ATTR RISCV_HOT_PATH() __attribute__((no_sanitize("undefined")))
+#else
+#define DISPATCH_ATTR RISCV_HOT_PATH()
+#endif
 
 template <int W> DISPATCH_ATTR
 bool CPU<W>::simulate(address_t pc, uint64_t inscounter, uint64_t maxcounter)

--- a/lib/libriscv/threaded_dispatch.cpp
+++ b/lib/libriscv/threaded_dispatch.cpp
@@ -1,6 +1,5 @@
 #include "common.hpp"
 #define DISPATCH_MODE_THREADED
-#define DISPATCH_ATTR RISCV_HOT_PATH()
 #define DISPATCH_FUNC simulate_threaded
 
 #define EXECUTE_INSTR()      \


### PR DESCRIPTION
Sanitizers and fuzzers should enable the fuzzing mode. Without the fuzzing mode we can assume that the UBsan minimal run-time is used, and we don't want to enable it for dispatch, as it hampers the emulator too much. Thus, disable UBsan for dispatch when not sanitizing.

There is afaik no way to detect UBsan minimal run-time.
