### PR TITLE
Add missing double type to vmcall fold

### DIFF
--- a/lib/libriscv/machine_vmcall.hpp
+++ b/lib/libriscv/machine_vmcall.hpp
@@ -16,8 +16,10 @@ inline void Machine<W>::setup_call(Args&&... args)
 			cpu.reg(iarg++) = stack_push(args.data(), args.size()+1);
 		else if constexpr (is_string<Args>::value)
 			cpu.reg(iarg++) = stack_push(args, strlen(args)+1);
-		else if constexpr (std::is_floating_point_v<remove_cvref<Args>>)
+		else if constexpr (std::is_same_v<float, remove_cvref<Args>>)
 			cpu.registers().getfl(farg++).set_float(args);
+		else if constexpr (std::is_same_v<double, remove_cvref<Args>>)
+			cpu.registers().getfl(farg++).f64 = args;
 		else if constexpr (std::is_standard_layout_v<remove_cvref<Args>>)
 			cpu.reg(iarg++) = stack_push(&args, sizeof(args));
 		else

--- a/tests/unit/vmcall.cpp
+++ b/tests/unit/vmcall.cpp
@@ -96,6 +96,12 @@ TEST_CASE("VM function call in fork", "[VMCall]")
 		return 3;
 	}
 
+	extern int fps(float f1, double d1) {
+		assert(f1 == 1.0f);
+		assert(d1 == 2.0);
+		return 4;
+	}
+
 	int main() {
 		value = 1;
 		return 666;
@@ -154,6 +160,9 @@ TEST_CASE("VM function call in fork", "[VMCall]")
 
 		int res3 = fork.vmcall("ints", 123L, intref, (long&&)intref);
 		REQUIRE(res3 == 3);
+
+		int res4 = fork.vmcall("fps", 1.0f, 2.0);
+		REQUIRE(res4 == 4);
 
 		// XXX: Binary translation currently "remembers" that arena
 		// was enabled, and will not disable it for the fork.


### PR DESCRIPTION
This adds 64-bit floating point to vmcall argument list. Should have been done a long time ago, but I guess it was never used by anything until now. I don't particularly like 64-bit FP for gaming, but for long-distance location vectors it was necessary.
