### PR TITLE
Make nanboxing optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Non goals:
 
 ## Benchmarks
 
-[STREAM benchmark](https://gist.github.com/fwsGonzo/a594727a9429cb29f2012652ad43fb37) [CoreMark: 15656](https://gist.github.com/fwsGonzo/7ef100ba4fe7116e97ddb20cf26e6879) vs 41382 native.
+[STREAM benchmark](https://gist.github.com/fwsGonzo/a594727a9429cb29f2012652ad43fb37) [CoreMark: 15802](https://gist.github.com/fwsGonzo/7ef100ba4fe7116e97ddb20cf26e6879) vs 41382 native.
 
 Run [D00M 1 in libriscv](/examples/doom) and see for yourself. It should use around 8% CPU at 60 fps.
 

--- a/lib/libriscv/common.hpp
+++ b/lib/libriscv/common.hpp
@@ -116,10 +116,16 @@ namespace riscv
 	static constexpr bool memory_alignment_check = true;
 	static constexpr bool verbose_branches_enabled = false;
 	static constexpr bool unaligned_memory_slowpaths = true;
+	static constexpr bool nanboxing = true;
 #else
 	static constexpr bool memory_alignment_check = false;
 	static constexpr bool verbose_branches_enabled = false;
 	static constexpr bool unaligned_memory_slowpaths = false;
+#ifdef RISCV_ALWAYS_NANBOXING // In order to override the default
+	static constexpr bool nanboxing = true;
+#else
+	static constexpr bool nanboxing = false;
+#endif
 #endif
 
 #ifdef RISCV_EXT_A

--- a/lib/libriscv/registers.hpp
+++ b/lib/libriscv/registers.hpp
@@ -32,14 +32,16 @@ namespace riscv
 		}
 		void set_float(float f) {
 			this->f32[0] = f;
-			this->nanbox();
+			if constexpr (nanboxing)
+				this->nanbox();
 		}
 		void set_double(double d) {
 			this->f64 = d;
 		}
 		void load_u32(uint32_t val) {
 			this->i32[0] = val;
-			this->nanbox();
+			if constexpr (nanboxing)
+				this->nanbox();
 		}
 		void load_u64(uint64_t val) {
 			this->i64 = val;

--- a/lib/libriscv/tr_api.cpp
+++ b/lib/libriscv/tr_api.cpp
@@ -104,11 +104,15 @@ typedef union {
 
 static inline void load_fl(fp64reg* reg, uint32_t fv) {
 	reg->i32[0] = fv;
+#ifdef RISCV_NANBOXING
 	reg->i32[1] = 0;
+#endif
 }
 static inline void set_fl(fp64reg* reg, float f) {
 	reg->f32[0] = f;
+#ifdef RISCV_NANBOXING
 	reg->i32[1] = 0;
+#endif
 }
 #define load_dbl(reg, dv) (reg)->i64 = (dv)
 #define set_dbl(reg, dv)  (reg)->f64 = (dv)

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1122,7 +1122,9 @@ void Emitter<W>::emit()
 			switch (fi.Itype.funct3) {
 			case 0x2: // FLW
 				this->memory_load<uint32_t>(from_fpreg(fi.Itype.rd) + ".i32[0]", "uint32_t", fi.Itype.rs1, fi.Itype.signed_imm());
-				code += from_fpreg(fi.Itype.rd) + ".i32[1] = 0;\n";
+				if constexpr (nanboxing) {
+					code += from_fpreg(fi.Itype.rd) + ".i32[1] = 0;\n";
+				}
 				break;
 			case 0x3: // FLD
 				this->memory_load<uint64_t>(from_fpreg(fi.Itype.rd) + ".i64", "uint64_t", fi.Itype.rs1, fi.Itype.signed_imm());

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -56,12 +56,15 @@ static std::unordered_map<std::string, std::string> create_defines_for(const Mac
 	defines.emplace("RISCV_ARENA_ROEND", std::to_string(machine.memory.initial_rodata_end()));
 	defines.emplace("RISCV_INS_COUNTER_OFF", std::to_string(ins_counter_offset));
 	defines.emplace("RISCV_MAX_COUNTER_OFF", std::to_string(max_counter_offset));
-#ifdef RISCV_EXT_C
-	defines.emplace("RISCV_EXT_C", "1");
-#endif
-#ifdef RISCV_EXT_VECTOR
-	defines.emplace("RISCV_EXT_VECTOR", std::to_string(RISCV_EXT_VECTOR));
-#endif
+	if constexpr (compressed_enabled) {
+		defines.emplace("RISCV_EXT_C", "1");
+	}
+	if constexpr (vector_extension) {
+		defines.emplace("RISCV_EXT_VECTOR", std::to_string(vector_extension));
+	}
+	if constexpr (nanboxing) {
+		defines.emplace("RISCV_NANBOXING", "1");
+	}
 	return defines;
 }
 


### PR DESCRIPTION
Nanboxing can still be (always) enabled with `RISCV_ALWAYS_NANBOXING`.
