### PR TITLE
bintr: Add some PC discoverability to potentially failing paths

### DIFF
--- a/lib/libriscv/decoder_cache.cpp
+++ b/lib/libriscv/decoder_cache.cpp
@@ -361,8 +361,10 @@ namespace riscv
 		if (it != handler_cache.end())
 			return it->second;
 
-		instr_handlers.push_back(new_handler);
-		const size_t idx = instr_handlers.size()-1;
+		if (UNLIKELY(handler_count >= instr_handlers.size()))
+			throw MachineException(INVALID_PROGRAM, "Too many instruction handlers");
+		instr_handlers[handler_count] = new_handler;
+		const size_t idx = handler_count++;
 		handler_cache.try_emplace(new_handler, idx);
 		return idx;
 	}

--- a/lib/libriscv/decoder_cache.hpp
+++ b/lib/libriscv/decoder_cache.hpp
@@ -64,9 +64,13 @@ struct DecoderData {
 #endif
 	}
 
-private:
 	static size_t handler_index_for(Handler new_handler);
-	static inline std::vector<Handler> instr_handlers;
+	static Handler* get_handlers() noexcept {
+		return &instr_handlers[0];
+	}
+private:
+	static inline std::array<Handler, 256> instr_handlers;
+	static inline std::size_t handler_count = 0;
 	static inline std::unordered_map<Handler, size_t> handler_cache;
 };
 

--- a/lib/libriscv/memory.cpp
+++ b/lib/libriscv/memory.cpp
@@ -42,7 +42,7 @@ namespace riscv
 				}
 #else
 				// TODO: XXX: Investigate if this is a time sink
-				this->m_arena.data = new PageData[pages_max];
+				this->m_arena.data = new PageData[pages_max + 1];
 				this->m_arena.pages = pages_max;
 #endif
 			}

--- a/lib/libriscv/memory.hpp
+++ b/lib/libriscv/memory.hpp
@@ -189,6 +189,7 @@ namespace riscv
 
 		bool uses_flat_memory_arena() const noexcept { return riscv::flat_readwrite_arena && this->m_arena.data != nullptr; }
 		void* memory_arena_ptr() const noexcept { return (void *)this->m_arena.data; }
+		auto& memory_arena_ptr_ref() const noexcept { return this->m_arena.data; }
 		address_t memory_arena_size() const noexcept { return this->m_arena.pages * Page::size(); }
 		address_t memory_arena_read_boundary() const noexcept { return this->m_arena.read_boundary; }
 		address_t memory_arena_write_boundary() const noexcept { return this->m_arena.write_boundary; }

--- a/lib/libriscv/tr_api.cpp
+++ b/lib/libriscv/tr_api.cpp
@@ -142,7 +142,7 @@ static struct CallbackTable {
 	void (*unknown_syscall)(CPU*, addr_t);
 	void (*system)(CPU*, uint32_t);
 	void (*execute)(CPU*, uint32_t);
-	void (*exception) (CPU*, int);
+	void (*exception) (CPU*, addr_t, int);
 	void (*trace) (CPU*, const char*, addr_t, uint32_t);
 	float  (*sqrtf32)(float);
 	double (*sqrtf64)(double);
@@ -178,7 +178,7 @@ static inline void jump(CPU* cpu, addr_t addr) {
 	if (__builtin_expect((addr & RISCV_ALIGN_MASK) == 0, 1)) {
 		cpu->pc = addr;
 	} else {
-		api.exception(cpu, MISALIGNED_INSTRUCTION);
+		api.exception(cpu, addr, MISALIGNED_INSTRUCTION);
 		UNREACHABLE();
 	}
 }

--- a/lib/libriscv/tr_api.cpp
+++ b/lib/libriscv/tr_api.cpp
@@ -132,6 +132,7 @@ typedef struct {
 #define PAGENO(x) ((addr_t)(x) >> 12)
 #define PAGEOFF(x) ((addr_t)(x) & 0xFFF)
 typedef void (*syscall_t) (CPU*);
+typedef void (*handler) (CPU*, uint32_t);
 
 static struct CallbackTable {
 	const char* (*mem_ld) (const CPU*, addr_t);
@@ -141,7 +142,8 @@ static struct CallbackTable {
 	syscall_t* syscalls;
 	void (*unknown_syscall)(CPU*, addr_t);
 	void (*system)(CPU*, uint32_t);
-	void (*execute)(CPU*, uint32_t);
+	unsigned (*execute)(CPU*, uint32_t);
+	handler* handlers;
 	void (*exception) (CPU*, addr_t, int);
 	void (*trace) (CPU*, const char*, addr_t, uint32_t);
 	float  (*sqrtf32)(float);

--- a/lib/libriscv/tr_api.cpp
+++ b/lib/libriscv/tr_api.cpp
@@ -153,13 +153,13 @@ static struct CallbackTable {
 	int (*cpop) (uint32_t);
 	int (*cpopl) (uint64_t);
 } api;
-static char* arena_base;
 #define INS_COUNTER(cpu) (*(uint64_t *)((uintptr_t)cpu + RISCV_INS_COUNTER_OFF))
 #define MAX_COUNTER(cpu) (*(uint64_t *)((uintptr_t)cpu + RISCV_MAX_COUNTER_OFF))
 static const addr_t ARENA_READ_BOUNDARY  = RISCV_ARENA_END - 0x1000;
 static const addr_t ARENA_WRITE_BOUNDARY = RISCV_ARENA_END - RISCV_ARENA_ROEND;
 #define ARENA_READABLE(x) ((x) - 0x1000 < ARENA_READ_BOUNDARY)
 #define ARENA_WRITABLE(x) ((x) - RISCV_ARENA_ROEND < ARENA_WRITE_BOUNDARY)
+#define ARENA_AT(cpu, x)  (*(char **)((uintptr_t)cpu + RISCV_ARENA_OFF))[x]
 
 static inline int do_syscall(CPU* cpu, uint64_t counter, uint64_t max_counter, addr_t sysno)
 {
@@ -205,11 +205,9 @@ static inline uint64_t MUL128(
 	return (middle << 32) | (uint32_t)p00;
 }
 
-extern void init(struct CallbackTable* table,
-	char*    abase)
+extern void init(struct CallbackTable* table)
 {
 	api = *table;
-	arena_base = abase;
 };
 
 typedef struct {

--- a/lib/libriscv/tr_api.hpp
+++ b/lib/libriscv/tr_api.hpp
@@ -15,7 +15,7 @@ namespace riscv {
 		void (*unknown_syscall)(CPU<W>&, address_type<W>);
 		void (*system)(CPU<W>&, uint32_t);
 		void (*execute)(CPU<W>&, uint32_t);
-		void (*trigger_exception)(CPU<W>&, int);
+		void (*trigger_exception)(CPU<W>&, address_type<W>, int);
 		void (*trace)(CPU<W>&, const char*, address_type<W>, uint32_t);
 		float  (*sqrtf32)(float);
 		double (*sqrtf64)(double);

--- a/lib/libriscv/tr_api.hpp
+++ b/lib/libriscv/tr_api.hpp
@@ -14,7 +14,8 @@ namespace riscv {
 		syscall_t<W>* syscalls;
 		void (*unknown_syscall)(CPU<W>&, address_type<W>);
 		void (*system)(CPU<W>&, uint32_t);
-		void (*execute)(CPU<W>&, uint32_t);
+		unsigned (*execute)(CPU<W>&, uint32_t);
+		void (**handlers)(CPU<W>&, uint32_t);
 		void (*trigger_exception)(CPU<W>&, address_type<W>, int);
 		void (*trace)(CPU<W>&, const char*, address_type<W>, uint32_t);
 		float  (*sqrtf32)(float);

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -190,7 +190,7 @@ struct Emitter
 			const address_t absolute_vaddr = tinfo.gp + imm;
 			if (absolute_vaddr >= 0x1000 && absolute_vaddr + sizeof(T) <= this->cpu.machine().memory.memory_arena_size()) {
 				add_code(
-					dst + " = " + cast + "*(" + type + "*)&arena_base[" + speculation_safe(absolute_vaddr) + "];"
+					dst + " = " + cast + "*(" + type + "*)&ARENA_AT(cpu, " + speculation_safe(absolute_vaddr) + ");"
 				);
 				return;
 			}
@@ -200,7 +200,7 @@ struct Emitter
 		if (cpu.machine().memory.uses_flat_memory_arena()) {
 			add_code(
 				"if (LIKELY(ARENA_READABLE(" + address + ")))",
-					dst + " = " + cast + "*(" + type + "*)&arena_base[" + speculation_safe(address) + "];",
+					dst + " = " + cast + "*(" + type + "*)&ARENA_AT(cpu, " + speculation_safe(address) + ");",
 				"else {",
 					"const char* " + data + " = api.mem_ld(cpu, PAGENO(" + address + "));",
 					dst + " = " + cast + "*(" + type + "*)&" + data + "[PAGEOFF(" + address + ")];",
@@ -221,7 +221,7 @@ struct Emitter
 			/* XXX: Check page permissions */
 			const address_t absolute_vaddr = tinfo.gp + imm;
 			if (absolute_vaddr >= this->cpu.machine().memory.initial_rodata_end() && absolute_vaddr < this->cpu.machine().memory.memory_arena_size()) {
-				add_code("*(" + type + "*)&arena_base[" + speculation_safe(absolute_vaddr) + "] = " + value + ";");
+				add_code("*(" + type + "*)&ARENA_AT(cpu, " + speculation_safe(absolute_vaddr) + ") = " + value + ";");
 			}
 			return;
 		}
@@ -230,7 +230,7 @@ struct Emitter
 		if (cpu.machine().memory.uses_flat_memory_arena()) {
 			add_code(
 				"if (LIKELY(ARENA_WRITABLE(" + address + ")))",
-				"  *(" + type + "*)&arena_base[" + speculation_safe(address) + "] = " + value + ";",
+				"  *(" + type + "*)&ARENA_AT(cpu, " + speculation_safe(address) + ") = " + value + ";",
 				"else {",
 				"  char *" + data + " = api.mem_st(cpu, PAGENO(" + address + "));",
 				"  *(" + type + "*)&" + data + "[PAGEOFF(" + address + ")] = " + value + ";",

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -661,15 +661,15 @@ void Emitter<W>::emit()
 							std::to_string(instr.Itype.shift64_imm() & (XLEN-1)));
 					} else if (instr.Itype.high_bits() == 0x280) {
 						// BSETI: Bit-set immediate
-						add_code(dst + " = " + src + " | (1UL << (" + std::to_string(instr.Itype.imm & (XLEN-1)) + "));");
+						add_code(dst + " = " + src + " | ((addr_t)1 << (" + std::to_string(instr.Itype.imm & (XLEN-1)) + "));");
 					}
 					else if (instr.Itype.high_bits() == 0x480) {
 						// BCLRI: Bit-clear immediate
-						add_code(dst + " = " + src + " & ~(1UL << (" + std::to_string(instr.Itype.imm & (XLEN-1)) + "));");
+						add_code(dst + " = " + src + " & ~((addr_t)1 << (" + std::to_string(instr.Itype.imm & (XLEN-1)) + "));");
 					}
 					else if (instr.Itype.high_bits() == 0x680) {
 						// BINVI: Bit-invert immediate
-						add_code(dst + " = " + src + " ^ (1UL << (" + std::to_string(instr.Itype.imm & (XLEN-1)) + "));");
+						add_code(dst + " = " + src + " ^ ((addr_t)1 << (" + std::to_string(instr.Itype.imm & (XLEN-1)) + "));");
 					} else {
 						UNKNOWN_INSTRUCTION();
 					}
@@ -873,13 +873,13 @@ void Emitter<W>::emit()
 				add_code(to_reg(instr.Rtype.rd) + " = " + to_reg(instr.Rtype.rs2) + " + (" + to_reg(instr.Rtype.rs1) + " << 3);");
 				break;
 			case 0x141: // BSET
-				add_code(to_reg(instr.Rtype.rd) + " = " + to_reg(instr.Rtype.rs1) + " | (1UL << (" + to_reg(instr.Rtype.rs2) + " & (XLEN-1)));");
+				add_code(to_reg(instr.Rtype.rd) + " = " + to_reg(instr.Rtype.rs1) + " | ((addr_t)1 << (" + to_reg(instr.Rtype.rs2) + " & (XLEN-1)));");
 				break;
 			case 0x142: // BCLR
-				add_code(to_reg(instr.Rtype.rd) + " = " + to_reg(instr.Rtype.rs1) + " & ~(1UL << (" + to_reg(instr.Rtype.rs2) + " & (XLEN-1)));");
+				add_code(to_reg(instr.Rtype.rd) + " = " + to_reg(instr.Rtype.rs1) + " & ~((addr_t)1 << (" + to_reg(instr.Rtype.rs2) + " & (XLEN-1)));");
 				break;
 			case 0x143: // BINV
-				add_code(to_reg(instr.Rtype.rd) + " = " + to_reg(instr.Rtype.rs1) + " ^ (1UL << (" + to_reg(instr.Rtype.rs2) + " & (XLEN-1)));");
+				add_code(to_reg(instr.Rtype.rd) + " = " + to_reg(instr.Rtype.rs1) + " ^ ((addr_t)1 << (" + to_reg(instr.Rtype.rs2) + " & (XLEN-1)));");
 				break;
 			case 0x204: // XNOR
 				add_code(to_reg(instr.Rtype.rd) + " = ~(" + to_reg(instr.Rtype.rs1) + " ^ " + to_reg(instr.Rtype.rs2) + ");");

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -616,10 +616,13 @@ bool CPU<W>::initialize_translated_segment(DecodedExecuteSegment<W>&, void* dyli
 		.system = [] (CPU<W>& cpu, uint32_t instr) {
 			cpu.machine().system(rv32i_instruction{instr});
 		},
-		.execute = [] (CPU<W>& cpu, uint32_t instr) {
+		.execute = [] (CPU<W>& cpu, uint32_t instr) -> unsigned {
 			const rv32i_instruction rvi{instr};
-			cpu.decode(rvi).handler(cpu, rvi);
+			auto* handler = cpu.decode(rvi).handler;
+			handler(cpu, rvi);
+			return DecoderData<W>::handler_index_for(handler);
 		},
+		.handlers = (void (**)(CPU<W>&, uint32_t)) DecoderData<W>::get_handlers(),
 		.trigger_exception = [] (CPU<W>& cpu, address_type<W> pc, int e) {
 			cpu.registers().pc = pc; // XXX: Set PC to the failing instruction (?)
 			cpu.trigger_exception(e);

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -53,6 +53,7 @@ static std::unordered_map<std::string, std::string> create_defines_for(const Mac
 	auto counters = const_cast<Machine<W>&> (machine).get_counters();
 	const auto ins_counter_offset = uintptr_t(&counters.first) - uintptr_t(&machine);
 	const auto max_counter_offset = uintptr_t(&counters.second) - uintptr_t(&machine);
+	const auto arena_offset = uintptr_t(&machine.memory.memory_arena_ptr_ref()) - uintptr_t(&machine);
 
 	std::unordered_map<std::string, std::string> defines;
 	defines.emplace("RISCV_TRANSLATION_DYLIB", std::to_string(W));
@@ -61,6 +62,7 @@ static std::unordered_map<std::string, std::string> create_defines_for(const Mac
 	defines.emplace("RISCV_ARENA_ROEND", std::to_string(machine.memory.initial_rodata_end()));
 	defines.emplace("RISCV_INS_COUNTER_OFF", std::to_string(ins_counter_offset));
 	defines.emplace("RISCV_MAX_COUNTER_OFF", std::to_string(max_counter_offset));
+	defines.emplace("RISCV_ARENA_OFF", std::to_string(arena_offset));
 	if constexpr (compressed_enabled) {
 		defines.emplace("RISCV_EXT_C", "1");
 	}
@@ -126,7 +128,7 @@ int CPU<W>::load_translation(const MachineOptions<W>& options,
 	// Always check if there is an existing file
 	if (access(filebuffer, R_OK) == 0) {
 		TIME_POINT(t7);
-		dylib = dlopen(filebuffer, RTLD_LAZY);
+		dylib = dlopen(filebuffer, RTLD_LAZY | RTLD_LOCAL);
 		if (options.translate_timing) {
 			TIME_POINT(t8);
 			printf(">> dlopen took %ld ns\n", nanodiff(t7, t8));
@@ -583,7 +585,7 @@ bool CPU<W>::initialize_translated_segment(DecodedExecuteSegment<W>&, void* dyli
 	}
 
 	// Map the API callback table
-	auto func = (void (*)(const CallbackTable<W>&, void*)) ptr;
+	auto func = (void (*)(const CallbackTable<W>&)) ptr;
 	func(CallbackTable<W>{
 		.mem_read = [] (CPU<W>& cpu, address_type<W> addr) -> const void* {
 			return cpu.machine().memory.cached_readable_page(addr << 12, 1).buffer8.data();
@@ -650,8 +652,7 @@ bool CPU<W>::initialize_translated_segment(DecodedExecuteSegment<W>&, void* dyli
 		.cpopl = [] (uint64_t x) -> int {
 			return std::popcount(x);
 		},
-	},
-	m_machine.memory.memory_arena_ptr());
+	});
 
 	return true;
 }


### PR DESCRIPTION
This PR solves a long-standing issue with binary translation, multiple shared objects and dlopen(). `static` variables are no longer used to store per-machine data, and instead offsets from the CPU is used. All these variables are baked into the checksum of the program, so there will never be a case of Windows players executing an incompatible program. Instead, if it is incompatible, it will just be disregarded.

It also adds a lazy fast-path for unknown instructions, allowing custom instructions to be faster in binary translation. They are lazily resolved in order for the shared object to work even if the order of instruction handlers change, and even for cross-compiled binary translations.
