### PR TITLE
bintr: Allow disabling arena per-program

### DIFF
--- a/.github/workflows/unittests_bintr.yml
+++ b/.github/workflows/unittests_bintr.yml
@@ -1,4 +1,4 @@
-name: Unit Tests
+name: Binary Translated Unit Tests
 
 on:
   push:
@@ -24,11 +24,11 @@ jobs:
         git submodule update --init ${{github.workspace}}/tests/unit/ext/lodepng
 
     - name: Configure
-      run: cmake -B ${{github.workspace}}/build -DRISCV_THREADED=OFF -DRISCV_FLAT_RW_ARENA=OFF -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DRISCV_THREADED=ON -DRISCV_BINARY_TRANSLATION=ON -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build the unittests
       run: cmake --build ${{github.workspace}}/build --parallel 4
 
     - name: Run tests
       working-directory: ${{github.workspace}}/build
-      run: ctest --verbose . -j2
+      run: CFLAGS=-O0 ctest --verbose . -j4

--- a/.github/workflows/unittests_exp.yml
+++ b/.github/workflows/unittests_exp.yml
@@ -42,4 +42,4 @@ jobs:
 
     - name: Run tests
       working-directory: ${{github.workspace}}/build
-      run: ctest --verbose .
+      run: ctest --verbose . -j2

--- a/.github/workflows/unittests_threaded.yml
+++ b/.github/workflows/unittests_threaded.yml
@@ -31,4 +31,4 @@ jobs:
 
     - name: Run tests
       working-directory: ${{github.workspace}}/build
-      run: ctest --verbose .
+      run: ctest --verbose . -j2

--- a/lib/libriscv/common.hpp
+++ b/lib/libriscv/common.hpp
@@ -120,6 +120,10 @@ namespace riscv
 		/// Translated shared objects will be stored in a file and can be re-used later.
 		/// @details When TCC is enabled, the translation cache will be disabled.
 		bool translation_cache = true;
+		/// @brief Enable the use of the memory arena for the binary translator.
+		/// @details If disabled, remote machines will be able to make remote
+		/// calls to this machine. In most cases, this is not needed.
+		bool translation_use_arena = true;
 		/// @brief Prefix for the translation output file.
 		std::string translation_prefix = "/tmp/rvbintr-";
 		/// @brief Suffix for the translation output file.

--- a/lib/libriscv/tr_api.cpp
+++ b/lib/libriscv/tr_api.cpp
@@ -157,8 +157,8 @@ static struct CallbackTable {
 } api;
 #define INS_COUNTER(cpu) (*(uint64_t *)((uintptr_t)cpu + RISCV_INS_COUNTER_OFF))
 #define MAX_COUNTER(cpu) (*(uint64_t *)((uintptr_t)cpu + RISCV_MAX_COUNTER_OFF))
-static const addr_t ARENA_READ_BOUNDARY  = RISCV_ARENA_END - 0x1000;
-static const addr_t ARENA_WRITE_BOUNDARY = RISCV_ARENA_END - RISCV_ARENA_ROEND;
+#define ARENA_READ_BOUNDARY  (RISCV_ARENA_END - 0x1000)
+#define ARENA_WRITE_BOUNDARY (RISCV_ARENA_END - RISCV_ARENA_ROEND)
 #define ARENA_READABLE(x) ((x) - 0x1000 < ARENA_READ_BOUNDARY)
 #define ARENA_WRITABLE(x) ((x) - RISCV_ARENA_ROEND < ARENA_WRITE_BOUNDARY)
 #define ARENA_AT(cpu, x)  (*(char **)((uintptr_t)cpu + RISCV_ARENA_OFF))[x]

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -305,6 +305,11 @@ struct Emitter
 	address_t pc() const noexcept { return this->m_pc; }
 	address_t begin_pc() const noexcept { return tinfo.basepc; }
 	address_t end_pc() const noexcept { return tinfo.endpc; }
+
+	bool within_segment(address_t addr) const noexcept {
+		return addr >= this->tinfo.segment_basepc && addr < this->tinfo.segment_endpc;
+	}
+
 	const std::string get_func() const noexcept { return this->func; }
 	void emit();
 	rv32i_instruction emit_rvc();
@@ -578,7 +583,9 @@ void Emitter<W>::emit()
 				}
 				// .. if we run out of instructions, we must jump manually and exit:
 			}
-			else if (this->tinfo.global_jump_locations.count(dest_pc)) {
+			else if (this->tinfo.global_jump_locations.count(dest_pc) && this->within_segment(dest_pc)) {
+				//printf("Global jump location: 0x%lX for block 0x%lX -> 0x%lX\n", long(dest_pc),
+				//	long(this->begin_pc()), long(this->end_pc()));
 				// Get the function name of the target block
 				auto target_funcaddr = this->find_block_base(dest_pc);
 				// Allow directly calling a function, as long as it's a forward jump

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -89,6 +89,9 @@ static std::unordered_map<std::string, std::string> create_defines_for(const Mac
 	defines.emplace("RISCV_INS_COUNTER_OFF", std::to_string(ins_counter_offset));
 	defines.emplace("RISCV_MAX_COUNTER_OFF", std::to_string(max_counter_offset));
 	defines.emplace("RISCV_ARENA_OFF", std::to_string(arena_offset));
+	if constexpr (atomics_enabled) {
+		defines.emplace("RISCV_EXT_A", "1");
+	}
 	if constexpr (compressed_enabled) {
 		defines.emplace("RISCV_EXT_C", "1");
 	}
@@ -137,7 +140,7 @@ int CPU<W>::load_translation(const MachineOptions<W>& options,
 	uint32_t checksum =
 		crc32c(exec_data, exec.exec_end() - exec.exec_begin());
 	// Also add the compiler flags to the checksum
-	checksum = crc32c(checksum, cflags.c_str(), cflags.size());
+	checksum = ~crc32c(~checksum, cflags.c_str(), cflags.size());
 	exec.set_translation_hash(checksum);
 
 	char filebuffer[256];

--- a/lib/libriscv/tr_types.hpp
+++ b/lib/libriscv/tr_types.hpp
@@ -14,6 +14,8 @@ namespace riscv
 		const std::vector<rv32i_instruction> instr;
 		address_type<W> basepc;
 		address_type<W> endpc;
+		address_type<W> segment_basepc;
+		address_type<W> segment_endpc;
 		address_type<W> gp;
 		bool trace_instructions;
 		bool forward_jumps;

--- a/tests/unit/vmcall.cpp
+++ b/tests/unit/vmcall.cpp
@@ -107,7 +107,10 @@ TEST_CASE("VM function call in fork", "[VMCall]")
 		return 666;
 	})M");
 
-	riscv::Machine<RISCV64> machine { binary, { .memory_max = MAX_MEMORY } };
+	riscv::Machine<RISCV64> machine { binary, {
+		.memory_max = MAX_MEMORY,
+		.use_memory_arena = false,
+	} };
 	machine.setup_linux_syscalls();
 	machine.setup_linux(
 		{"vmcall"},
@@ -120,7 +123,9 @@ TEST_CASE("VM function call in fork", "[VMCall]")
 	for (size_t i = 0; i < 10; i++)
 	{
 		riscv::Machine<RISCV64> fork { machine, {
-			.use_memory_arena = false
+#ifdef RISCV_BINARY_TRANSLATION
+			.use_memory_arena = false,
+#endif
 		} };
 		REQUIRE(fork.memory.uses_flat_memory_arena() == false);
 


### PR DESCRIPTION
Also, some changes to prevent local-jump to locations outside of the execute-segment.
This change enables executing remote calls into a binary translated machine (with fast-path arena disabled)
