### PR TITLE
Build and run test programs on 32-bit ARM

### DIFF
--- a/lib/libriscv/rva_instr.cpp
+++ b/lib/libriscv/rva_instr.cpp
@@ -1,7 +1,9 @@
 #include "cpu.hpp"
 
 #include "instr_helpers.hpp"
+#if __has_include(<atomic>)
 #include <atomic>
+#endif
 #include <cstdint>
 #include <inttypes.h>
 static const char atomic_type[] { '?', '?', 'W', 'D', 'Q', '?', '?', '?' };
@@ -11,7 +13,6 @@ static const char* atomic_name2[] {
 #define AMOSIZE_W   0x2
 #define AMOSIZE_D   0x3
 #define AMOSIZE_Q   0x4
-
 
 namespace riscv
 {
@@ -48,7 +49,13 @@ namespace riscv
 	{
 		cpu.template amo<int32_t>(instr,
 		[] (auto& cpu, auto& value, auto rs2) {
+#ifdef __cpp_lib_atomic_ref
 			return std::atomic_ref(value).fetch_add(cpu.reg(rs2));
+#else
+			auto old_value = value;
+			value += cpu.reg(rs2);
+			return old_value;
+#endif
 		});
 	},
 	[] (char* buffer, size_t len, auto&, rv32i_instruction instr) RVPRINTR_ATTR {
@@ -65,7 +72,13 @@ namespace riscv
 	{
 		cpu.template amo<int32_t>(instr,
 		[] (auto& cpu, auto& value, auto rs2) {
+#ifdef __cpp_lib_atomic_ref
 			return std::atomic_ref(value).fetch_xor(cpu.reg(rs2));
+#else
+			auto old_value = value;
+			value ^= cpu.reg(rs2);
+			return old_value;
+#endif
 		});
 	}, DECODED_ATOMIC(AMOADD_W).printer);
 
@@ -74,7 +87,13 @@ namespace riscv
 	{
 		cpu.template amo<int32_t>(instr,
 		[] (auto& cpu, auto& value, auto rs2) {
+#ifdef __cpp_lib_atomic_ref
 			return std::atomic_ref(value).fetch_or(cpu.reg(rs2));
+#else
+			auto old_value = value;
+			value |= cpu.reg(rs2);
+			return old_value;
+#endif
 		});
 	}, DECODED_ATOMIC(AMOADD_W).printer);
 
@@ -83,7 +102,13 @@ namespace riscv
 	{
 		cpu.template amo<int32_t>(instr,
 		[] (auto& cpu, auto& value, auto rs2) {
+#ifdef __cpp_lib_atomic_ref
 			return std::atomic_ref(value).fetch_and(cpu.reg(rs2));
+#else
+			auto old_value = value;
+			value &= cpu.reg(rs2);
+			return old_value;
+#endif
 		});
 	}, DECODED_ATOMIC(AMOADD_W).printer);
 
@@ -136,7 +161,13 @@ namespace riscv
 	{
 		cpu.template amo<int64_t>(instr,
 		[] (auto& cpu, auto& value, auto rs2) {
+#ifdef __cpp_lib_atomic_ref
 			return std::atomic_ref(value).fetch_add(cpu.reg(rs2));
+#else
+			auto old_value = value;
+			value += cpu.reg(rs2);
+			return old_value;
+#endif
 		});
 	}, DECODED_ATOMIC(AMOADD_W).printer);
 
@@ -145,7 +176,13 @@ namespace riscv
 	{
 		cpu.template amo<int64_t>(instr,
 		[] (auto& cpu, auto& value, auto rs2) {
+#ifdef __cpp_lib_atomic_ref
 			return std::atomic_ref(value).fetch_xor(cpu.reg(rs2));
+#else
+			auto old_value = value;
+			value ^= cpu.reg(rs2);
+			return old_value;
+#endif
 		});
 	}, DECODED_ATOMIC(AMOADD_W).printer);
 
@@ -154,7 +191,13 @@ namespace riscv
 	{
 		cpu.template amo<int64_t>(instr,
 		[] (auto& cpu, auto& value, auto rs2) {
+#ifdef __cpp_lib_atomic_ref
 			return std::atomic_ref(value).fetch_or(cpu.reg(rs2));
+#else
+			auto old_value = value;
+			value |= cpu.reg(rs2);
+			return old_value;
+#endif
 		});
 	}, DECODED_ATOMIC(AMOADD_W).printer);
 
@@ -163,7 +206,13 @@ namespace riscv
 	{
 		cpu.template amo<int64_t>(instr,
 		[] (auto& cpu, auto& value, auto rs2) {
+#ifdef __cpp_lib_atomic_ref
 			return std::atomic_ref(value).fetch_and(cpu.reg(rs2));
+#else
+			auto old_value = value;
+			value &= cpu.reg(rs2);
+			return old_value;
+#endif
 		});
 	}, DECODED_ATOMIC(AMOADD_W).printer);
 
@@ -216,9 +265,13 @@ namespace riscv
 	{
 		cpu.template amo<int32_t>(instr,
 		[] (auto& cpu, auto& value, auto rs2) {
+#ifdef __cpp_lib_atomic_ref
+			return std::atomic_ref(value).exchange(cpu.reg(rs2));
+#else
 			auto old_value = value;
 			value = cpu.reg(rs2);
 			return old_value;
+#endif
 		});
 	},
 	[] (char* buffer, size_t len, auto&, rv32i_instruction instr) RVPRINTR_ATTR {
@@ -234,9 +287,13 @@ namespace riscv
 	{
 		cpu.template amo<int64_t>(instr,
 		[] (auto& cpu, auto& value, auto rs2) {
+#ifdef __cpp_lib_atomic_ref
+			return std::atomic_ref(value).exchange(cpu.reg(rs2));
+#else
 			auto old_value = value;
 			value = cpu.reg(rs2);
 			return old_value;
+#endif
 		});
 	}, DECODED_ATOMIC(AMOSWAP_W).printer);
 


### PR DESCRIPTION
This PR finalizes some fallback code in order to run 32- and 64-bit RISC-V programs on 32-bit ARM. There are still some warnings left (especially in remote debugging), but the CLI is running nicely.
