### PR TITLE
bintr: Try to re-enter translation immediately

### DIFF
--- a/lib/libriscv/common.hpp
+++ b/lib/libriscv/common.hpp
@@ -132,7 +132,6 @@ namespace riscv
 		/// @brief Limits placed on the binary translator.
 		/// @details The binary translator will stop translating after reaching
 		/// either of these limits. The limits are per shared object.
-		unsigned block_size_treshold = 5;
 		unsigned translate_blocks_max = 16'000;
 		unsigned translate_instr_max = 150'000;
 		/// @brief Allow the production of a secondary dependency-free DLL that can be

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -208,12 +208,12 @@ struct Emitter
 				"if (LIKELY(ARENA_READABLE(" + address + ")))",
 					dst + " = " + cast + "*(" + type + "*)&ARENA_AT(cpu, " + speculation_safe(address) + ");",
 				"else {",
-					"const char* " + data + " = api.mem_ld(cpu, PAGENO(" + address + "));",
+					"const char* " + data + " = api.mem_ld(cpu, " + address + ");",
 					dst + " = " + cast + "*(" + type + "*)&" + data + "[PAGEOFF(" + address + ")];",
 				"}");
 		} else {
 			add_code(
-				"const char* " + data + " = api.mem_ld(cpu, PAGENO(" + address + "));",
+				"const char* " + data + " = api.mem_ld(cpu, " + address + ");",
 				dst + " = " + cast + "*(" + type + "*)&" + data + "[PAGEOFF(" + address + ")];"
 			);
 		}
@@ -238,11 +238,11 @@ struct Emitter
 				"if (LIKELY(ARENA_WRITABLE(" + address + ")))",
 				"  *(" + type + "*)&ARENA_AT(cpu, " + speculation_safe(address) + ") = " + value + ";",
 				"else {",
-				"  char *" + data + " = api.mem_st(cpu, PAGENO(" + address + "));",
+				"  char *" + data + " = api.mem_st(cpu, " + address + ");",
 				"  *(" + type + "*)&" + data + "[PAGEOFF(" + address + ")] = " + value + ";",
 				"}");
 		} else {
-			add_code("char* " + data + " = api.mem_st(cpu, PAGENO(" + address + "));");
+			add_code("char* " + data + " = api.mem_st(cpu, " + address + ");");
 			add_code(
 				"*(" + type + "*)&" + data + "[PAGEOFF(" + address + ")] = " + value + ";"
 			);

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -386,8 +386,7 @@ if constexpr (SCAN_FOR_GP) {
 
 		// Process block and add it for emission
 		const size_t length = block_instructions.size();
-		if (length >= options.block_size_treshold
-			&& icounter + length < options.translate_instr_max)
+		if (length > 0 && icounter + length < options.translate_instr_max)
 		{
 			if constexpr (VERBOSE_BLOCKS) {
 				printf("Block found at %#lX -> %#lX. Length: %zu\n", long(block), long(block_end), length);

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -610,10 +610,10 @@ bool CPU<W>::initialize_translated_segment(DecodedExecuteSegment<W>&, void* dyli
 	auto func = (void (*)(const CallbackTable<W>&)) ptr;
 	func(CallbackTable<W>{
 		.mem_read = [] (CPU<W>& cpu, address_type<W> addr) -> const void* {
-			return cpu.machine().memory.cached_readable_page(addr << 12, 1).buffer8.data();
+			return cpu.machine().memory.cached_readable_page(addr, 1).buffer8.data();
 		},
 		.mem_write = [] (CPU<W>& cpu, address_type<W> addr) -> void* {
-			return cpu.machine().memory.cached_writable_page(addr << 12).buffer8.data();
+			return cpu.machine().memory.cached_writable_page(addr).buffer8.data();
 		},
 		.vec_load = [] (CPU<W>& cpu, int vd, address_type<W> addr) {
 #ifdef RISCV_EXT_VECTOR


### PR DESCRIPTION
Try to quickly re-enter binary translation. This change makes a lot of sense now that larger portions of the program is binary translated. Also fix a bug with memory traps and binary translation fallback reads/writes.
