### PR TITLE
bintr: Convert jump() to JUMP_TO() macro

### DIFF
--- a/lib/libriscv/tr_api.cpp
+++ b/lib/libriscv/tr_api.cpp
@@ -177,9 +177,8 @@ static inline int do_syscall(CPU* cpu, uint64_t counter, uint64_t max_counter, a
 	return (cpu->pc != old_pc || counter >= MAX_COUNTER(cpu));
 }
 
-static inline void jump(CPU* cpu, addr_t addr) {
+#define JUMP_TO(cpu, addr) \
 	cpu->pc = addr & ~(addr_t)RISCV_ALIGN_MASK;
-}
 
 // https://stackoverflow.com/questions/28868367/getting-the-high-part-of-64-bit-integer-multiplication
 // As written by catid

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -569,11 +569,11 @@ void Emitter<W>::emit()
 				add_code(
 					"{addr_t rs1 = " + from_reg(instr.Itype.rs1) + ";",
 					to_reg(instr.Itype.rd) + " = " + PCRELS(m_instr_length) + ";",
-					"jump(cpu, rs1 + " + from_imm(instr.Itype.signed_imm()) + "); }"
+					"JUMP_TO(cpu, rs1 + " + from_imm(instr.Itype.signed_imm()) + "); }"
 				);
 			} else {
 				add_code(
-					"jump(cpu, " + from_reg(instr.Itype.rs1) + " + " + from_imm(instr.Itype.signed_imm()) + ");"
+					"JUMP_TO(cpu, " + from_reg(instr.Itype.rs1) + " + " + from_imm(instr.Itype.signed_imm()) + ");"
 				);
 			}
 			exit_function("cpu->pc", true);


### PR DESCRIPTION
This will likely help TCC and -O0 performance a bit