### PR TITLE
bintr: Embed libtcc properly and build libtcc1.a

### DIFF
--- a/.github/workflows/bintr.yml
+++ b/.github/workflows/bintr.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install -y gcc-12-riscv64-linux-gnu g++-12-riscv64-linux-gnu gcc g++ libtcc-dev cmake
+        sudo apt install -y gcc-12-riscv64-linux-gnu g++-12-riscv64-linux-gnu gcc g++ cmake
 
     - name: Configure emulator
       env:

--- a/.github/workflows/packaging_libtcc.yml
+++ b/.github/workflows/packaging_libtcc.yml
@@ -1,0 +1,56 @@
+name: Debian Packaging w/libtcc JIT
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  BUILD_TYPE: RelWithDebInfo
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        compiler: [g++, clang++-17]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y g++ clang
+
+    - name: Install newer Clang
+      run: |
+       wget https://apt.llvm.org/llvm.sh
+       chmod +x ./llvm.sh
+       sudo ./llvm.sh 17
+
+    - name: CMake configuration
+      working-directory: ${{github.workspace}}/
+      env:
+        CXX: ${{ matrix.compiler }}
+
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DRISCV_BINARY_TRANSLATION=ON -DRISCV_LIBTCC=ON
+
+    - name: Build and packaging
+      run: |
+        cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+        pushd build
+        cpack -G DEB
+        popd
+        pushd packages
+        sudo dpkg -i *.deb
+        popd
+
+    - name: Build and run the package example
+      run: |
+        pushd examples/package
+        bash build_and_run.sh
+        popd

--- a/.github/workflows/unittests_libtcc.yml
+++ b/.github/workflows/unittests_libtcc.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install -y gcc-12-riscv64-linux-gnu g++-12-riscv64-linux-gnu libtcc-dev tcc
+        sudo apt install -y gcc-12-riscv64-linux-gnu g++-12-riscv64-linux-gnu
         git submodule update --init ${{github.workspace}}/tests/Catch2
         git submodule update --init ${{github.workspace}}/tests/unit/ext/lodepng
 
@@ -31,4 +31,4 @@ jobs:
 
     - name: Run tests
       working-directory: ${{github.workspace}}/build
-      run: CFLAGS=-O0 ctest --verbose . -j4
+      run: ctest --verbose . -j4

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ riscv32-unknown-elf/
 emulator/*rvmicro
 emulator/*rvnewlib
 emulator/*rvlinux
+emulator/libtcc1.a
 nodiverge
 tests/autotest/emulator/emulator
 binaries/crc32/clmul

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 
 RUN apt update && apt install -y \
-	cmake \
+	cmake git \
 	clang-18 \
 	tcc libtcc-dev \
 	g++-13-riscv64-linux-gnu
@@ -16,7 +16,7 @@ COPY binaries/measure_mips/fib.c /app/emulator/fib.c
 
 # Fast emulation (with TCC JIT compilation)
 WORKDIR /app/emulator
-RUN ./build.sh --tcc && cp .build/rvlinux /app/rvlinux
+RUN ./build.sh --tcc && cp .build/rvlinux /app/rvlinux && cp .build/libtcc1.a /app/libtcc1.a
 
 # Fastest emulator (with binary translation)
 WORKDIR /app/emulator

--- a/emulator/build.sh
+++ b/emulator/build.sh
@@ -42,4 +42,7 @@ fi
 if test -f ".build/rvnewlib"; then
 	ln -fs .build/rvnewlib .
 fi
+if test -f ".build/libtcc1.a"; then
+	ln -fs .build/libtcc1.a .
+fi
 ln -fs .build/rvlinux .

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -134,7 +134,11 @@ if (RISCV_BINARY_TRANSLATION)
 endif()
 
 configure_file(libriscv_settings.h.in ${CMAKE_CURRENT_BINARY_DIR}/libriscv_settings.h)
-configure_file(libriscv.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libriscv.pc)
+if (RISCV_LIBTCC)
+	configure_file(libriscv_libtcc.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libriscv.pc)
+else()
+	configure_file(libriscv.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libriscv.pc)
+endif()
 
 add_library(riscv ${SOURCES})
 target_compile_features(riscv PUBLIC cxx_std_20)
@@ -164,6 +168,7 @@ if (RISCV_LIBTCC)
 	if(CMAKE_VERSION VERSION_LESS "3.14.0") 
 		target_link_libraries(riscv PUBLIC libtcc.a dl)
 		target_compile_definitions(riscv PUBLIC LIBTCC_PACKAGE=1)
+		set(LIBTCC_FROM_PACKAGE TRUE)
 	else()
 		include(FetchContent)
 		FetchContent_Declare(
@@ -174,6 +179,14 @@ if (RISCV_LIBTCC)
 		FetchContent_MakeAvailable(libtcc)
 		target_compile_definitions(libtcc PUBLIC LIBTCC1_NAME="libtcc1.a")
 		target_link_libraries(riscv PUBLIC libtcc libtcc1)
+		set(LIBTCC_FROM_PACKAGE FALSE)
+
+		# Installed version will need to find libtcc
+		if (${CMAKE_PROJECT_NAME} STREQUAL "libriscv")
+			target_compile_definitions(riscv PUBLIC
+				LIBTCC_LIBRARY_PATH="/usr/lib/libriscv"
+			)
+		endif()
 	endif()
 endif()
 
@@ -239,4 +252,14 @@ if (${CMAKE_PROJECT_NAME} STREQUAL "libriscv")
 		FILES ${CMAKE_CURRENT_BINARY_DIR}/libriscv.pc
 		DESTINATION lib/pkgconfig
 	)
+	if (RISCV_LIBTCC)
+		# Install our own copy of libtcc, if we're not using the system package
+		if (NOT LIBTCC_FROM_PACKAGE)
+			install(FILES
+				${CMAKE_BINARY_DIR}/_deps/libtcc-build/libtcc.a
+				${CMAKE_BINARY_DIR}/libtcc1.a
+				DESTINATION lib/${PROJECT_NAME}
+			)
+		endif()
+	endif()
 endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -162,7 +162,7 @@ endif()
 
 if (RISCV_LIBTCC)
 	if(CMAKE_VERSION VERSION_LESS "3.14.0") 
-		target_link_libraries(riscv PUBLIC libtcc.a)
+		target_link_libraries(riscv PUBLIC libtcc.a dl)
 		target_compile_definitions(riscv PUBLIC LIBTCC_PACKAGE=1)
 	else()
 		include(FetchContent)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -161,16 +161,20 @@ endif()
 
 
 if (RISCV_LIBTCC)
-	#include(FetchContent)
-	#FetchContent_Declare(
-	#	libtcc
-	#	GIT_REPOSITORY    https://github.com/fwsGonzo/libtcc-cmake
-	#	GIT_TAG           master
-	#)
-	#FetchContent_MakeAvailable(libtcc)
-	#target_compile_definitions(libtcc PUBLIC LIBTCC1_NAME="libtcc1.a")
-
-	target_link_libraries(riscv PUBLIC libtcc.a)
+	if(CMAKE_VERSION VERSION_LESS "3.14.0") 
+		target_link_libraries(riscv PUBLIC libtcc.a)
+		target_compile_definitions(riscv PUBLIC LIBTCC_PACKAGE=1)
+	else()
+		include(FetchContent)
+		FetchContent_Declare(
+			libtcc
+			GIT_REPOSITORY    https://github.com/fwsGonzo/libtcc-cmake
+			GIT_TAG           master
+		)
+		FetchContent_MakeAvailable(libtcc)
+		target_compile_definitions(libtcc PUBLIC LIBTCC1_NAME="libtcc1.a")
+		target_link_libraries(riscv PUBLIC libtcc libtcc1)
+	endif()
 endif()
 
 if (${CMAKE_PROJECT_NAME} STREQUAL "libriscv")

--- a/lib/libriscv/machine_defaults.cpp
+++ b/lib/libriscv/machine_defaults.cpp
@@ -28,7 +28,7 @@ namespace riscv
 		return 0;
 	}
 
-	// Default: RDTIME produces monotonic time with *millisecond*-granularity
+	// Default: RDTIME produces monotonic time with *microsecond*-granularity
 	template <int W>
 	uint64_t Machine<W>::default_rdtime(const Machine<W>&) {
 		auto now = std::chrono::steady_clock::now();

--- a/lib/libriscv/tr_tcc.cpp
+++ b/lib/libriscv/tr_tcc.cpp
@@ -1,8 +1,12 @@
 #include "common.hpp"
+
 #ifdef LIBTCC_PACKAGE
-#include <libtcc.h>
+# include <libtcc.h>
 #else
-#include <tcc/libtcc.h>
+# include <tcc/libtcc.h>
+# ifndef LIBTCC_LIBRARY_PATH
+#  define LIBTCC_LIBRARY_PATH "."
+# endif
 #endif
 
 namespace riscv
@@ -22,9 +26,8 @@ namespace riscv
 
 		if (!libtcc1.empty())
 			tcc_add_library_path(state, libtcc1.c_str());
-#ifndef LIBTCC_PACKAGE
-		else
-			tcc_add_library_path(state, ".");
+#ifdef LIBTCC_LIBRARY_PATH
+		tcc_add_library_path(state, LIBTCC_LIBRARY_PATH);
 #endif
 
 		if (tcc_compile_string(state, code.c_str()) < 0) {

--- a/lib/libriscv/tr_tcc.cpp
+++ b/lib/libriscv/tr_tcc.cpp
@@ -1,5 +1,9 @@
 #include "common.hpp"
+#ifdef LIBTCC_PACKAGE
 #include <libtcc.h>
+#else
+#include <tcc/libtcc.h>
+#endif
 
 namespace riscv
 {
@@ -18,6 +22,10 @@ namespace riscv
 
 		if (!libtcc1.empty())
 			tcc_add_library_path(state, libtcc1.c_str());
+#ifndef LIBTCC_PACKAGE
+		else
+			tcc_add_library_path(state, ".");
+#endif
 
 		if (tcc_compile_string(state, code.c_str()) < 0) {
 			tcc_delete(state);

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -1,4 +1,7 @@
+#if __has_include(<bit>)
 #include <bit>
+#define RISCV_HAS_BITOPS
+#endif
 #include <cmath>
 #include <chrono>
 #include <mutex>
@@ -736,22 +739,46 @@ bool CPU<W>::initialize_translated_segment(DecodedExecuteSegment<W>&, void* dyli
 			return std::sqrt(d);
 		},
 		.clz = [] (uint32_t x) -> int {
+#ifdef RISCV_HAS_BITOPS
 			return std::countl_zero(x);
+#else
+			return x ? __builtin_clz(x) : 32;
+#endif
 		},
 		.clzl = [] (uint64_t x) -> int {
+#ifdef RISCV_HAS_BITOPS
 			return std::countl_zero(x);
+#else
+			return x ? __builtin_clzl(x) : 64;
+#endif
 		},
 		.ctz = [] (uint32_t x) -> int {
+#ifdef RISCV_HAS_BITOPS
 			return std::countr_zero(x);
+#else
+			return x ? __builtin_ctz(x) : 0;
+#endif
 		},
 		.ctzl = [] (uint64_t x) -> int {
+#ifdef RISCV_HAS_BITOPS
 			return std::countr_zero(x);
+#else
+			return x ? __builtin_ctzl(x) : 0;
+#endif
 		},
 		.cpop = [] (uint32_t x) -> int {
+#ifdef RISCV_HAS_BITOPS
 			return std::popcount(x);
+#else
+			return __builtin_popcount(x);
+#endif
 		},
 		.cpopl = [] (uint64_t x) -> int {
+#ifdef RISCV_HAS_BITOPS
 			return std::popcount(x);
+#else
+			return __builtin_popcountl(x);
+#endif
 		},
 	});
 

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -19,6 +19,7 @@ extern "C" int unlink(const char* path);
 # endif
 #else
 # include <dlfcn.h>
+# include <unistd.h>
 #endif
 #include "machine.hpp"
 #include "decoder_cache.hpp"

--- a/lib/libriscv_libtcc.pc.in
+++ b/lib/libriscv_libtcc.pc.in
@@ -1,0 +1,6 @@
+Name: @CMAKE_PROJECT_NAME@
+Description: @CMAKE_PROJECT_DESCRIPTION@
+URL: https://github.com/fwsGonzo/libriscv
+Version: @PROJECT_VERSION@
+Cflags: -I/usr/include
+Libs: -L/usr/lib -lriscv -l:libriscv/libtcc.a


### PR DESCRIPTION
This PR attempts to fully embed libtcc in the build process, so that it doesn't have to be installed as a system package. It's WIP and won't work with the installed version of libriscv yet.

For now the goal is just to see if it passes the test suite.
