### PR TITLE
Add experimental unbounded 32-bit arena support

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -45,6 +45,17 @@ if (RISCV_EXPERIMENTAL)
 	# MULTIPROCESS enables experimental features that allow
 	# executing RISC-V guest functions in parallel using a custom API.
 	option(RISCV_MULTIPROCESS        "Enable multiprocessing" OFF)
+	# RISCV_ENCOMPASSING_ARENA allows the memory arena to encompass
+	# the entire memory space, allowing for more efficient memory
+	# accesses, but is only available for 32-bit RISC-V.
+	option(RISCV_ENCOMPASSING_ARENA  "Enable encompassing memory arena" OFF)
+	if (RISCV_ENCOMPASSING_ARENA AND NOT RISCV_32I)
+		message(FATAL_ERROR "RISCV_ENCOMPASSING_ARENA requires RISCV_32I to be enabled")
+	endif()
+	if (RISCV_ENCOMPASSING_ARENA)
+		# Encompassing arena implies flat read-write arena
+		set(RISCV_FLAT_RW_ARENA ON)
+	endif()
 endif()
 if (RISCV_BINARY_TRANSLATION)
 	# LIBTCC will embed the TCC compiler library, using it for binary translation.

--- a/lib/libriscv/common.hpp
+++ b/lib/libriscv/common.hpp
@@ -236,6 +236,11 @@ namespace riscv
 #else
 	static constexpr bool flat_readwrite_arena = false;
 #endif
+#ifdef RISCV_ENCOMPASSING_ARENA
+	static constexpr bool encompassing_32bit_arena = true;
+#else
+	static constexpr bool encompassing_32bit_arena = false;
+#endif
 #ifdef RISCV_LIBTCC
 	static constexpr bool libtcc_enabled = true;
 #else

--- a/lib/libriscv/memory.hpp
+++ b/lib/libriscv/memory.hpp
@@ -188,6 +188,7 @@ namespace riscv
 		bool is_dynamic_executable() const noexcept { return this->m_is_dynamic; }
 
 		bool uses_flat_memory_arena() const noexcept { return riscv::flat_readwrite_arena && this->m_arena.data != nullptr; }
+		bool uses_32bit_encompassing_arena() const noexcept { return riscv::encompassing_32bit_arena && this->m_arena.data != nullptr; }
 		void* memory_arena_ptr() const noexcept { return (void *)this->m_arena.data; }
 		auto& memory_arena_ptr_ref() const noexcept { return this->m_arena.data; }
 		address_t memory_arena_size() const noexcept { return this->m_arena.pages * Page::size(); }

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -620,7 +620,7 @@ bool CPU<W>::initialize_translated_segment(DecodedExecuteSegment<W>&, void* dyli
 	static uint64_t scratch_buffer[4];
 
 	// Map the API callback table
-	auto func = (void (*)(const CallbackTable<W>&)) ptr;
+	auto func = (void (*)(const CallbackTable<W>&, void*)) ptr;
 	func(CallbackTable<W>{
 		.mem_read = [] (CPU<W>& cpu, address_type<W> addr) -> const void* {
 			if constexpr (libtcc_enabled) {
@@ -784,7 +784,9 @@ bool CPU<W>::initialize_translated_segment(DecodedExecuteSegment<W>&, void* dyli
 			return __builtin_popcountl(x);
 #endif
 		},
-	});
+	},
+		machine().memory.memory_arena_ptr_ref()
+	);
 
 	return true;
 }

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -110,6 +110,9 @@ static std::unordered_map<std::string, std::string> create_defines_for(const Mac
 		// so it will be recompiled if the trace option is toggled.
 		defines.emplace("RISCV_TRACING", "1");
 	}
+	if constexpr (W == 4 && encompassing_32bit_arena) {
+		defines.emplace("RISCV_32BIT_UNBOUNDED", "1");
+	}
 	return defines;
 }
 

--- a/lib/libriscv_settings.h.in
+++ b/lib/libriscv_settings.h.in
@@ -17,6 +17,7 @@
 #cmakedefine RISCV_MULTIPROCESS
 #cmakedefine RISCV_BINARY_TRANSLATION
 #cmakedefine RISCV_FLAT_RW_ARENA
+#cmakedefine RISCV_ENCOMPASSING_ARENA
 #cmakedefine RISCV_THREADED
 #cmakedefine RISCV_TAILCALL_DISPATCH
 #cmakedefine RISCV_LIBTCC


### PR DESCRIPTION
The initial code to map the entire 4GB address space for 32-bit guests in order to avoid bound-checks on memory reads and writes. So far the performance increase is fairly modest, < 10%.

```
$ VERBOSE=1 ./rvlinux -v ~/github/coremark/coremark-rv32g_b 
* Loading program of size 75145 from 0x7f6ba52ec010 to virtual 0x10000
* Program segment readable: 1 writable: 0  executable: 1
* Loading program of size 1864 from 0x7f6ba52fe59c to virtual 0x2358c
* Program segment readable: 1 writable: 1  executable: 0
* Entry is at 0x109f4
2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 14508
Total time (secs): 14.508000
Iterations/Sec   : 20678.246485
Iterations       : 300000
Compiler version : GCC13.2.0
Compiler flags   : -O3 -DPERFORMANCE_RUN=1  
Memory location  : Please put data memory location here
			(e.g. code in flash, data on heap etc)
seedcrc          : 0xe9f5
[0]crclist       : 0xe714
[0]crcmatrix     : 0x1fd7
[0]crcstate      : 0x8e3a
[0]crcfinal      : 0xcc42
Correct operation validated. See README.md for run and reporting rules.
CoreMark 1.0 : 20678.246485 / GCC13.2.0 -O3 -DPERFORMANCE_RUN=1   / Static
>>> Program exited, exit code = 0 (0x0)
Instructions executed: 119355767074  Runtime: 19870.079ms  Insn/s: 6007mi/s
Pages in use: 25 (100 kB virtual memory, total 319 kB)
```
