### PR TITLE
Make all execute segments backed by shared_ptr

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -185,7 +185,7 @@ endif()
 
 if (RISCV_LIBTCC)
 	if(CMAKE_VERSION VERSION_LESS "3.14.0" OR RISCV_LIBTCC_DISTRO_PACKAGE) 
-		target_link_libraries(riscv PUBLIC libtcc.a)
+		target_link_libraries(riscv PUBLIC -l:libtcc.a)
 		set_source_files_properties(libriscv/tr_tcc.cpp PROPERTIES
 			COMPILE_DEFINITIONS RISCV_LIBTCC_PACKAGE=1)
 		set(LIBTCC_FROM_PACKAGE TRUE)

--- a/lib/libriscv/cpu.cpp
+++ b/lib/libriscv/cpu.cpp
@@ -9,10 +9,10 @@ namespace riscv
 	// A default empty execute segment used to enforce that the
 	// current CPU execute segment is never null.
 	template <int W>
-	static DecodedExecuteSegment<W> empty(0, 0, 0, 0);
+	static std::shared_ptr<DecodedExecuteSegment<W>> empty_shared = std::make_shared<DecodedExecuteSegment<W>>(0, 0, 0, 0);
 	template <int W>
-	DecodedExecuteSegment<W>& CPU<W>::empty_execute_segment() {
-		return empty<W>;
+	std::shared_ptr<DecodedExecuteSegment<W>>& CPU<W>::empty_execute_segment() {
+		return empty_shared<W>;
 	}
 
 	// Instructions may be unaligned with C-extension
@@ -108,7 +108,7 @@ restart_next_execute_segment:
 		}
 
 		// Find previously decoded execute segment
-		this->m_exec = &machine().memory.exec_segment_for(pc);
+		this->m_exec = machine().memory.exec_segment_for(pc).get();
 		if (LIKELY(!this->m_exec->empty())) {
 			return {this->m_exec, pc};
 		}

--- a/lib/libriscv/cpu.hpp
+++ b/lib/libriscv/cpu.hpp
@@ -128,7 +128,7 @@ namespace riscv
 			address_t pc;
 		};
 		NextExecuteReturn next_execute_segment(address_t pc);
-		static DecodedExecuteSegment<W>& empty_execute_segment();
+		static std::shared_ptr<DecodedExecuteSegment<W>>& empty_execute_segment();
 		bool is_executable(address_t addr) const noexcept;
 
 		// Override the function that gets called when the CPU
@@ -171,7 +171,7 @@ namespace riscv
 
 		// The default execute override returns no new execute segment
 		override_execute_segment_t m_override_exec = [] (auto&) -> DecodedExecuteSegment<W>& {
-			return empty_execute_segment();
+			return *empty_execute_segment();
 		};
 
 #ifdef RISCV_BINARY_TRANSLATION

--- a/lib/libriscv/cpu_inline.hpp
+++ b/lib/libriscv/cpu_inline.hpp
@@ -19,7 +19,7 @@ const Memory<W>& CPU<W>::memory() const noexcept { return machine().memory; }
 
 template <int W>
 inline CPU<W>::CPU(Machine<W>& machine, unsigned cpu_id)
-	: m_machine { machine }, m_exec(&empty_execute_segment()), m_cpuid { cpu_id }
+	: m_machine { machine }, m_exec(empty_execute_segment().get()), m_cpuid { cpu_id }
 {
 }
 template <int W>

--- a/lib/libriscv/decoded_exec_segment.hpp
+++ b/lib/libriscv/decoded_exec_segment.hpp
@@ -55,6 +55,9 @@ namespace riscv
 
 		size_t threaded_rewrite(size_t bytecode, address_t pc, rv32i_instruction& instr);
 
+		uint32_t crc32c_hash() const noexcept { return m_crc32c_hash; }
+		void set_crc32c_hash(uint32_t hash) { m_crc32c_hash = hash; }
+
 #ifdef RISCV_BINARY_TRANSLATION
 		bool is_binary_translated() const noexcept { return m_bintr_dl != nullptr; }
 		void* binary_translation_so() const { return m_bintr_dl; }
@@ -93,6 +96,7 @@ namespace riscv
 		mutable void* m_bintr_dl = nullptr;
 		uint32_t m_bintr_hash = 0x0; // CRC32-C of the execute segment + compiler options
 #endif
+		uint32_t m_crc32c_hash = 0x0; // CRC32-C of the execute segment
 	};
 
 	template <int W>

--- a/lib/libriscv/memory.cpp
+++ b/lib/libriscv/memory.cpp
@@ -137,6 +137,8 @@ namespace riscv
 	Memory<W>::~Memory()
 	{
 		this->clear_all_pages();
+		// remove execute segments
+		this->evict_execute_segments(0);
 		// only the original machine owns arena
 		if (this->m_arena.data != nullptr && !is_forked()) {
 #ifdef __linux__

--- a/lib/libriscv/memory.hpp
+++ b/lib/libriscv/memory.hpp
@@ -174,9 +174,8 @@ namespace riscv
 			address_t dst, void* src, size_t size, PageAttributes = {});
 
 		// Custom execute segment, returns page base, final size and execute segment pointer
-		DecodedExecuteSegment<W>& exec_segment_for(address_t vaddr);
-		const DecodedExecuteSegment<W>& exec_segment_for(address_t vaddr) const;
-		const DecodedExecuteSegment<W>& main_execute_segment() const { return m_exec.at(0); }
+		std::shared_ptr<DecodedExecuteSegment<W>>& exec_segment_for(address_t vaddr);
+		const std::shared_ptr<DecodedExecuteSegment<W>>& exec_segment_for(address_t vaddr) const;
 		DecodedExecuteSegment<W>& create_execute_segment(const MachineOptions<W>&, const void* data, address_t addr, size_t len);
 		size_t cached_execute_segments() const noexcept { return m_exec_segs; }
 		// Evict newest execute segments until only remaining left
@@ -277,9 +276,9 @@ namespace riscv
 #endif
 
 		// Execute segments
-		std::array<DecodedExecuteSegment<W>, MAX_EXECUTE_SEGS> m_exec;
+		std::array<std::shared_ptr<DecodedExecuteSegment<W>>, MAX_EXECUTE_SEGS> m_exec;
 		size_t m_exec_segs = 0;
-		DecodedExecuteSegment<W>& next_execute_segment();
+		std::shared_ptr<DecodedExecuteSegment<W>>& next_execute_segment();
 
 		// Linear arena at start of memory (mmap-backed)
 		struct alignas(16) {

--- a/lib/libriscv/memory_rw.cpp
+++ b/lib/libriscv/memory_rw.cpp
@@ -323,7 +323,8 @@ namespace riscv
 		}
 
 		for (const auto& exec : m_exec) {
-			total += exec.size_bytes();
+			if (exec)
+				total += exec->size_bytes();
 		}
 
 		return total;

--- a/lib/libriscv/tr_api.cpp
+++ b/lib/libriscv/tr_api.cpp
@@ -165,13 +165,8 @@ static struct CallbackTable {
 #define ARENA_WRITABLE(x) ((x) - RISCV_ARENA_ROEND < ARENA_WRITE_BOUNDARY)
 
 INTERNAL static char* arena_ptr;
-#define ARENA_AT(cpu, x)  arena_ptr[x]
-
-//#ifdef __TINYC__
 //#define ARENA_AT(cpu, x)  arena_ptr[x]
-//#else
-//#define ARENA_AT(cpu, x)  (*(char **)((uintptr_t)cpu + RISCV_ARENA_OFF))[x]
-//#endif
+#define ARENA_AT(cpu, x)  (*(char **)((uintptr_t)cpu + RISCV_ARENA_OFF))[x]
 
 static inline int do_syscall(CPU* cpu, uint64_t counter, uint64_t max_counter, addr_t sysno)
 {

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -141,14 +141,14 @@ int CPU<W>::load_translation(const MachineOptions<W>& options,
 		throw MachineException(ILLEGAL_OPERATION, "Execute segment already binary translated");
 	}
 
-	auto* exec_data = exec.exec_data(exec.exec_begin());
-
 	// Checksum the execute segment + compiler flags
 	TIME_POINT(t5);
 	const std::string cflags = defines_to_string(create_defines_for(machine(), options));
 	extern std::string compile_command(int arch, const std::string& cflags);
-	uint32_t checksum =
-		crc32c(exec_data, exec.exec_end() - exec.exec_begin());
+	uint32_t checksum = exec.crc32c_hash();
+	if (UNLIKELY(checksum == 0)) {
+		throw MachineException(INVALID_PROGRAM, "Invalid execute segment hash for translation");
+	}
 	// Also add the compiler flags to the checksum
 	checksum = ~crc32c(~checksum, cflags.c_str(), cflags.size());
 	exec.set_translation_hash(checksum);


### PR DESCRIPTION
With the JIT-compilation feature it now makes more sense to have it enabled while iterating on code. However, if you have, say, 30 emulators all running the same programs, none of them are currently sharing those segments. On idea to solve this was to make some kind of light forking constructor. Instead, I thought it would be nice if it was fully automatic. So, instead I will make execute segments shared and create a structure with serialized access that maintains known execute segments by simple atomic reference counting. So, if an emulator is providing an execute segment, it will count as 2, while if one emulator is loaning it, it will count as 1. It should all count down to zero in the end.

As a drawback, the TCC memory optimization I made earlier today must now be undone. It makes memory operations slightly faster by relying on libtcc being fast enough to produce a unique segment for each machine, despite running the same program. In the end, the benefit might not be worth it outside of CLI emulation. So, I will disable it but leave the code visible. The optimization relies on the fact that TCC struggles with register allocation and accessing a single static is less performant than a direct pointer.
