### PR TITLE
bintr: Add missing re-entry after JALR

### DIFF
--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -625,6 +625,7 @@ void Emitter<W>::emit()
 				);
 			}
 			exit_function("cpu->pc", false);
+			this->add_reentry_next();
 			} break;
 		case RV32I_JAL: {
 			this->increment_counter_so_far();


### PR DESCRIPTION
This missed a few optimizations, and crucially fixes performance with script functions
