### PR TITLE
Improved prepared calls

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -145,7 +145,7 @@ if (RISCV_BINARY_TRANSLATION)
 endif()
 
 configure_file(libriscv_settings.h.in ${CMAKE_CURRENT_BINARY_DIR}/libriscv_settings.h)
-if (RISCV_LIBTCC)
+if (RISCV_BINARY_TRANSLATION AND RISCV_LIBTCC)
 	option(RISCV_LIBTCC_DISTRO_PACKAGE "Use the distributions libtcc" OFF)
 
 	if (RISCV_LIBTCC_DISTRO_PACKAGE)
@@ -183,7 +183,7 @@ elseif (RISCV_BINARY_TRANSLATION)
 endif()
 
 
-if (RISCV_LIBTCC)
+if (RISCV_BINARY_TRANSLATION AND RISCV_LIBTCC)
 	if(CMAKE_VERSION VERSION_LESS "3.14.0" OR RISCV_LIBTCC_DISTRO_PACKAGE) 
 		target_link_libraries(riscv PUBLIC -l:libtcc.a)
 		set_source_files_properties(libriscv/tr_tcc.cpp PROPERTIES
@@ -272,7 +272,7 @@ if (${CMAKE_PROJECT_NAME} STREQUAL "libriscv")
 		FILES ${CMAKE_CURRENT_BINARY_DIR}/libriscv.pc
 		DESTINATION lib/pkgconfig
 	)
-	if (RISCV_LIBTCC)
+	if (RISCV_BINARY_TRANSLATION AND RISCV_LIBTCC)
 		# Install our own copy of libtcc, if we're not using the system package
 		if (NOT LIBTCC_FROM_PACKAGE)
 			install(FILES

--- a/lib/libriscv/tr_api.cpp
+++ b/lib/libriscv/tr_api.cpp
@@ -136,8 +136,8 @@ typedef void (*syscall_t) (CPU*);
 typedef void (*handler) (CPU*, uint32_t);
 
 static struct CallbackTable {
-	const char* (*mem_ld) (const CPU*, addr_t);
-	char* (*mem_st) (const CPU*, addr_t);
+	addr_t (*mem_ld) (const CPU*, addr_t, unsigned);
+	void (*mem_st) (const CPU*, addr_t, addr_t, unsigned);
 	void (*vec_load)(const CPU*, int, addr_t);
 	void (*vec_store)(const CPU*, addr_t, int);
 	syscall_t* syscalls;

--- a/lib/libriscv/tr_api.hpp
+++ b/lib/libriscv/tr_api.hpp
@@ -7,8 +7,8 @@ namespace riscv {
 
 	template <int W>
 	struct CallbackTable {
-		const void* (*mem_read)(CPU<W>&, address_type<W> addr);
-		void* (*mem_write) (CPU<W>&, address_type<W> addr);
+		address_type<W> (*mem_read)(CPU<W>&, address_type<W> addr, unsigned size);
+		void (*mem_write) (CPU<W>&, address_type<W> addr, address_type<W> value, unsigned size);
 		void (*vec_load)(CPU<W>&, int vd, address_type<W> addr);
 		void (*vec_store) (CPU<W>&, address_type<W> addr, int vd);
 		syscall_t<W>* syscalls;

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -252,13 +252,11 @@ struct Emitter
 				"if (LIKELY(ARENA_READABLE(" + address + ")))",
 					dst + " = " + cast + "*(" + type + "*)&" + arena_at(address) + ";",
 				"else {",
-					"const char* " + data + " = api.mem_ld(cpu, " + address + ");",
-					dst + " = " + cast + "*(" + type + "*)&" + data + "[PAGEOFF(" + address + ")];",
+					dst + " = " + cast + "(" + type + ")api.mem_ld(cpu, " + address + ", " + std::to_string(sizeof(T)) + ");",
 				"}");
 		} else {
 			add_code(
-				"const char* " + data + " = api.mem_ld(cpu, " + address + ");",
-				dst + " = " + cast + "*(" + type + "*)&" + data + "[PAGEOFF(" + address + ")];"
+				dst + " = " + cast + "(" + type + ")api.mem_ld(cpu, " + address + ", " + std::to_string(sizeof(T)) + ");"
 			);
 		}
 	}
@@ -286,13 +284,11 @@ struct Emitter
 				"if (LIKELY(ARENA_WRITABLE(" + address + ")))",
 				"  *(" + type + "*)&" + arena_at(address) + " = " + value + ";",
 				"else {",
-				"  char *" + data + " = api.mem_st(cpu, " + address + ");",
-				"  *(" + type + "*)&" + data + "[PAGEOFF(" + address + ")] = " + value + ";",
+				"  api.mem_st(cpu, " + address + ", " + value + ", sizeof(" + type + "));",
 				"}");
 		} else {
-			add_code("char* " + data + " = api.mem_st(cpu, " + address + ");");
 			add_code(
-				"*(" + type + "*)&" + data + "[PAGEOFF(" + address + ")] = " + value + ";"
+				"api.mem_st(cpu, " + address + ", " + value + ", sizeof(" + type + "));"
 			);
 		}
 	}
@@ -634,6 +630,7 @@ void Emitter<W>::emit()
 			}
 			// XXX: mask off unaligned jumps - is this OK?
 			const auto dest_pc = (this->pc() + instr.Jtype.jump_offset()) & ~address_t(ALIGN_MASK);
+			bool add_reentry = instr.Jtype.rd != 0;
 			// forward label: jump inside code block
 			if (dest_pc >= this->begin_pc() && dest_pc < this->end_pc()) {
 				// forward labels require creating future labels
@@ -647,7 +644,7 @@ void Emitter<W>::emit()
 					// so make sure it's accessible (add a re-entry point)
 					// TODO: Check if the next instruction is a public symbol address
 					if (instr.Jtype.rd == 0)
-						this->add_reentry_next();
+						add_reentry = true;
 				} else {
 					// jump backwards: use counters
 					add_code("if (" + LOOP_EXPRESSION + ") goto " + FUNCLABEL(dest_pc) + ";");
@@ -655,7 +652,7 @@ void Emitter<W>::emit()
 					// so make sure it's accessible (add a re-entry point)
 					// TODO: Check if the next instruction is a public symbol address
 					if (instr.Jtype.rd == 0)
-						this->add_reentry_next();
+						add_reentry = true;
 				}
 				// .. if we run out of instructions, we must jump manually and exit:
 			}
@@ -695,7 +692,7 @@ void Emitter<W>::emit()
 
 			// Because of forward jumps we can't end the function here
 			exit_function(STRADDR(dest_pc), false);
-			if (instr.Jtype.rd != 0)
+			if (add_reentry)
 				this->add_reentry_next();
 			} break;
 


### PR DESCRIPTION
An attempt at short-circuiting binary translated functions when directly called

The current prepared calls are designed such that they are the most useful to me, but it doesn't seem like they are lowering latency despite clearly "doing less". Very frustrating situation.
