### PR TITLE
bintr: Improve TCC execution of unknown instructions

### DIFF
--- a/lib/libriscv/cpu.hpp
+++ b/lib/libriscv/cpu.hpp
@@ -144,10 +144,10 @@ namespace riscv
 		static const instruction_t& get_unimplemented_instruction() noexcept;
 
 		// Set current exception
-		void set_current_exception(unsigned exception) noexcept { m_current_exception = exception + 1; }
-		void clear_current_exception() noexcept { m_current_exception = 0; }
-		bool has_current_exception() const noexcept { return m_current_exception != 0; }
-		exceptions current_exception() const noexcept { return exceptions(m_current_exception-1); }
+		void set_current_exception(std::exception_ptr&& ptr) noexcept { m_current_exception = std::move(ptr); }
+		void clear_current_exception() noexcept { m_current_exception = nullptr; }
+		bool has_current_exception() const noexcept { return m_current_exception != nullptr; }
+		auto& current_exception() const noexcept { return m_current_exception; }
 
 	private:
 		Registers<W> m_regs;
@@ -162,7 +162,7 @@ namespace riscv
 		const unsigned m_cpuid;
 
 		// The current exception (used by eg. TCC which doesn't create unwinding tables)
-		unsigned m_current_exception = 0;
+		std::exception_ptr m_current_exception = nullptr;
 
 		// The default execute fault simply triggers the exception
 		execute_fault_t m_fault = [] (auto& cpu, auto&) {

--- a/lib/libriscv/tr_api.cpp
+++ b/lib/libriscv/tr_api.cpp
@@ -145,6 +145,7 @@ static struct CallbackTable {
 	void (*unknown_syscall)(CPU*, addr_t);
 	void (*system)(CPU*, uint32_t);
 	unsigned (*execute)(CPU*, uint32_t);
+	unsigned (*execute_handler)(CPU*, unsigned, uint32_t);
 	handler* handlers;
 	void (*exception) (CPU*, addr_t, int);
 	void (*trace) (CPU*, const char*, addr_t, uint32_t);

--- a/lib/libriscv/tr_api.hpp
+++ b/lib/libriscv/tr_api.hpp
@@ -16,6 +16,7 @@ namespace riscv {
 		void (*unknown_syscall)(CPU<W>&, address_type<W>);
 		void (*system)(CPU<W>&, uint32_t);
 		unsigned (*execute)(CPU<W>&, uint32_t);
+		unsigned (*execute_handler)(CPU<W>&, unsigned, uint32_t);
 		void (**handlers)(CPU<W>&, uint32_t);
 		void (*trigger_exception)(CPU<W>&, address_type<W>, int);
 		void (*trace)(CPU<W>&, const char*, address_type<W>, uint32_t);

--- a/lib/libriscv/tr_tcc.cpp
+++ b/lib/libriscv/tr_tcc.cpp
@@ -27,6 +27,11 @@ namespace riscv
 		tcc_define_symbol(state, "ARCH", "HOST_UNKNOWN");
 		tcc_set_options(state, "-std=c99 -O2");
 
+#ifdef _WIN32
+		// Look for some headers in the win32 directory
+		tcc_add_include_path(state, "win32");
+#endif
+
 		if (!libtcc1.empty())
 			tcc_add_library_path(state, libtcc1.c_str());
 #ifdef LIBTCC_LIBRARY_PATH

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -634,8 +634,8 @@ bool CPU<W>::initialize_translated_segment(DecodedExecuteSegment<W>&, void* dyli
 					case 8: return cpu.machine().memory.template read<uint64_t>(addr);
 					default: throw MachineException(ILLEGAL_OPERATION, "Invalid memory read size", size);
 					}
-				} catch (const MachineException& e) {
-					cpu.set_current_exception(e.type());
+				} catch (...) {
+					cpu.set_current_exception(std::current_exception());
 					cpu.machine().stop();
 					return 0;
 				}
@@ -659,8 +659,8 @@ bool CPU<W>::initialize_translated_segment(DecodedExecuteSegment<W>&, void* dyli
 					case 8: cpu.machine().memory.template write<uint64_t>(addr, value); break;
 					default: throw MachineException(ILLEGAL_OPERATION, "Invalid memory write size", size);
 					}
-				} catch (const MachineException& e) {
-					cpu.set_current_exception(e.type());
+				} catch (...) {
+					cpu.set_current_exception(std::current_exception());
 					cpu.machine().stop();
 				}
 			} else {
@@ -696,12 +696,8 @@ bool CPU<W>::initialize_translated_segment(DecodedExecuteSegment<W>&, void* dyli
 					const auto current_pc = cpu.registers().pc;
 					cpu.machine().system_call(sysno);
 					return cpu.registers().pc != current_pc || cpu.machine().stopped();
-				} catch (const MachineException& e) {
-					cpu.set_current_exception(e.type());
-					cpu.machine().stop();
-					return false;
-				} catch (const std::exception& e) {
-					cpu.set_current_exception(SYSTEM_CALL_FAILED);
+				} catch (...) {
+					cpu.set_current_exception(std::current_exception());
 					cpu.machine().stop();
 					return false;
 				}
@@ -716,11 +712,8 @@ bool CPU<W>::initialize_translated_segment(DecodedExecuteSegment<W>&, void* dyli
 			if constexpr (libtcc_enabled) {
 				try {
 					cpu.machine().system(rv32i_instruction{instr});
-				} catch (const MachineException& e) {
-					cpu.set_current_exception(e.type());
-					cpu.machine().stop();
-				} catch (const std::exception& e) {
-					cpu.set_current_exception(SYSTEM_CALL_FAILED);
+				} catch (...) {
+					cpu.set_current_exception(std::current_exception());
 					cpu.machine().stop();
 				}
 			} else {
@@ -733,11 +726,8 @@ bool CPU<W>::initialize_translated_segment(DecodedExecuteSegment<W>&, void* dyli
 				try {
 					cpu.decode(rvi).handler(cpu, rvi);
 					return 0;
-				} catch (const MachineException& e) {
-					cpu.set_current_exception(e.type());
-					return 1;
-				} catch (const std::exception& e) {
-					cpu.set_current_exception(SYSTEM_CALL_FAILED);
+				} catch (...) {
+					cpu.set_current_exception(std::current_exception());
 					return 1;
 				}
 			} else {
@@ -751,11 +741,8 @@ bool CPU<W>::initialize_translated_segment(DecodedExecuteSegment<W>&, void* dyli
 			try {
 				DecoderData<W>::get_handlers()[index](cpu, rvi);
 				return 0;
-			} catch (const MachineException& e) {
-				cpu.set_current_exception(e.type());
-				return 1;
-			} catch (const std::exception& e) {
-				cpu.set_current_exception(SYSTEM_CALL_FAILED);
+			} catch (...) {
+				cpu.set_current_exception(std::current_exception());
 				return 1;
 			}
 		},
@@ -766,9 +753,13 @@ bool CPU<W>::initialize_translated_segment(DecodedExecuteSegment<W>&, void* dyli
 				// If we're using libtcc, we can't throw C++ exceptions because
 				// there's no unwinding support. But we can mark an exception
 				// in the CPU state and return back to dispatch.
-				cpu.set_current_exception(e);
-				// Trigger a slow-path in dispatch (which will check for exceptions)
-				cpu.machine().stop();
+				try {
+					cpu.trigger_exception(e);
+				} catch (...) {
+					cpu.set_current_exception(std::current_exception());
+					// Trigger a slow-path in dispatch (which will check for exceptions)
+					cpu.machine().stop();
+				}
 			} else {
 				cpu.trigger_exception(e);
 			}


### PR DESCRIPTION
- Handle all exceptions properly
- Store and re-throw actual exception thrown
- Since TCC JIT is ephemeral, use instruction handler indices directly, avoiding decoding