### PR TITLE
Implement N-bit encompassing arena

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -50,6 +50,8 @@ if (RISCV_EXPERIMENTAL)
 	# accesses, but is only available for 32-bit RISC-V.
 	option(RISCV_ENCOMPASSING_ARENA  "Enable encompassing memory arena" OFF)
 	if (RISCV_ENCOMPASSING_ARENA)
+		# Encompassing arena defaults to 32-bit address space, but it is configurable (power of 2).
+		set(RISCV_ENCOMPASSING_ARENA_BITS "32" CACHE STRING "Encompassing arena address space bits")
 		# Encompassing arena implies flat read-write arena
 		set(RISCV_FLAT_RW_ARENA ON)
 	endif()
@@ -163,6 +165,12 @@ target_include_directories(riscv PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 if (NOT WIN32 OR MINGW_TOOLCHAIN)
 	target_compile_options(riscv PRIVATE -Wall -Wextra)
+endif()
+
+if (RISCV_ENCOMPASSING_ARENA)
+	target_compile_definitions(riscv PUBLIC
+		RISCV_ENCOMPASSING_ARENA_BITS=${RISCV_ENCOMPASSING_ARENA_BITS}
+	)
 endif()
 
 if (RISCV_MULTIPROCESS)

--- a/lib/libriscv/common.hpp
+++ b/lib/libriscv/common.hpp
@@ -244,9 +244,11 @@ namespace riscv
 	static constexpr bool flat_readwrite_arena = false;
 #endif
 #ifdef RISCV_ENCOMPASSING_ARENA
-	static constexpr bool encompassing_32bit_arena = true;
+	static constexpr int encompassing_Nbit_arena = RISCV_ENCOMPASSING_ARENA_BITS;
+	static constexpr uint64_t encompassing_arena_mask = (1ull << RISCV_ENCOMPASSING_ARENA_BITS) - 1;
 #else
-	static constexpr bool encompassing_32bit_arena = false;
+	static constexpr int encompassing_Nbit_arena = 0;
+	static constexpr uint64_t encompassing_arena_mask = 0;
 #endif
 #ifdef RISCV_LIBTCC
 	static constexpr bool libtcc_enabled = true;

--- a/lib/libriscv/memory.cpp
+++ b/lib/libriscv/memory.cpp
@@ -49,7 +49,7 @@ namespace riscv
 						this->m_arena.data = nullptr;
 						throw MachineException(OUT_OF_MEMORY, "Out of memory", UNBOUNDED_ARENA_SIZE);
 					}
-					this->m_arena.pages = pages_max;
+					this->m_arena.pages = (1ULL << encompassing_Nbit_arena) / Page::size();
 					/*this->m_arena.data = (PageData *)mmap(m_arena.data, (pages_max + 1) * Page::size(), PROT_READ | PROT_WRITE,
 						MAP_FIXED | MAP_ANONYMOUS | MAP_PRIVATE | MAP_NORESERVE, -1, 0);
 					if (UNLIKELY(this->m_arena.data == MAP_FAILED)) {

--- a/lib/libriscv/memory.cpp
+++ b/lib/libriscv/memory.cpp
@@ -11,7 +11,7 @@ __cxa_demangle(const char *name, char *buf, size_t *n, int *status);
 
 namespace riscv
 {
-	static constexpr uint64_t UNBOUNDED_ARENA_SIZE = (1ULL << encompassing_Nbit_arena) + (16ULL << 20);
+	static constexpr uint64_t UNBOUNDED_ARENA_SIZE = (1ULL << encompassing_Nbit_arena) + Page::size();
 
 	template <int W>
 	Memory<W>::Memory(Machine<W>& mach, std::string_view bin,
@@ -37,8 +37,7 @@ namespace riscv
 					static_assert(flat_readwrite_arena || encompassing_Nbit_arena == 0,
 						"N-bit encompassing arena requires flat_readwrite_arena to be enabled");
 					// Allocate a complete N-bit arena, covering the entire N-bit address space
-					// Add 16MB extra to avoid having to check for overflow for some helper functions
-					// TODO: Allocate maximum signed offset below 0x0 for bounds-checking?
+					// Add 1 extra page to avoid having to bounds-check memory accesses
 					// TODO: Allocate unpresent pages for the whole address space,
 					// and only allocate real memory according to pages_max. Then handle
 					// page faults for the rest of the address space using userfaultfd.

--- a/lib/libriscv/memory.hpp
+++ b/lib/libriscv/memory.hpp
@@ -187,7 +187,7 @@ namespace riscv
 		bool is_dynamic_executable() const noexcept { return this->m_is_dynamic; }
 
 		bool uses_flat_memory_arena() const noexcept { return riscv::flat_readwrite_arena && this->m_arena.data != nullptr; }
-		bool uses_32bit_encompassing_arena() const noexcept { return riscv::encompassing_32bit_arena && this->m_arena.data != nullptr; }
+		bool uses_Nbit_encompassing_arena() const noexcept { return riscv::encompassing_Nbit_arena != 0 && this->m_arena.data != nullptr; }
 		void* memory_arena_ptr() const noexcept { return (void *)this->m_arena.data; }
 		auto& memory_arena_ptr_ref() const noexcept { return this->m_arena.data; }
 		address_t memory_arena_size() const noexcept { return this->m_arena.pages * Page::size(); }

--- a/lib/libriscv/memory_inline.hpp
+++ b/lib/libriscv/memory_inline.hpp
@@ -19,9 +19,12 @@ T Memory<W>::read(address_t address)
 			return value;
 		}
 	}
-	else if constexpr (encompassing_32bit_arena)
+	else if constexpr (encompassing_Nbit_arena)
 	{
-		return *(T *)&((const char*)m_arena.data)[uint32_t(address)];
+		if constexpr (encompassing_Nbit_arena == 32)
+			return *(T *)&((const char*)m_arena.data)[uint32_t(address)];
+		else // It's a power-of-two encompassing arena
+			return *(T *)&((const char*)m_arena.data)[address & encompassing_arena_mask];
 	}
 	else if constexpr (flat_readwrite_arena) {
 		if (LIKELY(address - RWREAD_BEGIN < memory_arena_read_boundary())) {
@@ -45,9 +48,12 @@ template <int W>
 template <typename T> inline
 T& Memory<W>::writable_read(address_t address)
 {
-	if constexpr (encompassing_32bit_arena)
+	if constexpr (encompassing_Nbit_arena)
 	{
-		return *(T *)&((char*)m_arena.data)[uint32_t(address)];
+		if constexpr (encompassing_Nbit_arena == 32)
+			return *(T *)&((char*)m_arena.data)[uint32_t(address)];
+		else // It's a power-of-two encompassing arena
+			return *(T *)&((char*)m_arena.data)[address & encompassing_arena_mask];
 	}
 	else if constexpr (flat_readwrite_arena) {
 		if (LIKELY(address - initial_rodata_end() < memory_arena_write_boundary())) {
@@ -71,9 +77,12 @@ void Memory<W>::write(address_t address, T value)
 			return;
 		}
 	}
-	else if constexpr (encompassing_32bit_arena)
+	else if constexpr (encompassing_Nbit_arena)
 	{
-		*(T *)&((char*)m_arena.data)[uint32_t(address)] = value;
+		if constexpr (encompassing_Nbit_arena == 32)
+			*(T *)&((char*)m_arena.data)[uint32_t(address)] = value;
+		else // It's a power-of-two encompassing arena
+			*(T *)&((char*)m_arena.data)[address & encompassing_arena_mask] = value;
 		return;
 	}
 	else if constexpr (flat_readwrite_arena) {

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -113,8 +113,8 @@ static std::unordered_map<std::string, std::string> create_defines_for(const Mac
 	if (options.translate_ignore_instruction_limit) {
 		defines.emplace("RISCV_IGNORE_INSTRUCTION_LIMIT", "1");
 	}
-	if constexpr (W == 4 && encompassing_32bit_arena) {
-		defines.emplace("RISCV_32BIT_UNBOUNDED", "1");
+	if constexpr (encompassing_Nbit_arena != 0) {
+		defines.emplace("RISCV_NBIT_UNBOUNDED", std::to_string(encompassing_Nbit_arena));
 	}
 	return defines;
 }


### PR DESCRIPTION
Expand the 32-bit arena concept to allow any power-of-two. This makes it possible for me to use it in a place where there are a bunch of emulators, each not requiring much memory.

Very experimental!