### PR TITLE
FreeBSD build

### DIFF
--- a/lib/libriscv/linux/system_calls.cpp
+++ b/lib/libriscv/linux/system_calls.cpp
@@ -24,6 +24,9 @@ static constexpr bool verbose_syscalls = false;
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/uio.h>
+#ifndef EBADFD
+#define EBADFD EBADF  // OpenBSD, FreeBSD
+#endif
 #define SA_ONSTACK	0x08000000
 
 namespace riscv {

--- a/lib/libriscv/posix/socket_calls.cpp
+++ b/lib/libriscv/posix/socket_calls.cpp
@@ -11,7 +11,10 @@
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#if __has_include(<linux/netlink.h>)
+#define HAVE_LINUX_NETLINK
 #include <linux/netlink.h>
+#endif
 #else
 #include "../win32/ws2.hpp"
 WSADATA riscv::ws2::global_winsock_data;
@@ -68,11 +71,13 @@ static void print_address(std::array<char, 128> buffer, address_type<W> addrlen)
 		printf("SYSCALL -- UNIX address: %s\n", sun->sun_path);
 		break;
 	}
+#ifdef HAVE_LINUX_NETLINK
 	case AF_NETLINK: {
 		auto* snl = (struct sockaddr_nl *)buffer.data();
 		printf("SYSCALL -- NetLink port: %u\n", snl->nl_pid);
 		break;
 	}
+#endif
 	}
 }
 #endif
@@ -105,7 +110,9 @@ static void syscall_socket(Machine<W>& machine)
 		case AF_UNIX: domname = "Unix"; break;
 		case AF_INET: domname = "IPv4"; break;
 		case AF_INET6: domname = "IPv6"; break;
+#ifdef HAVE_LINUX_NETLINK
 		case AF_NETLINK: domname = "Netlink"; break;
+#endif
 		default: domname = "unknown";
 	}
 	const char* typname;

--- a/lib/libriscv/tr_api.cpp
+++ b/lib/libriscv/tr_api.cpp
@@ -2,7 +2,20 @@
 
 namespace riscv {
 	extern const std::string bintr_code =
-		R"123(#include <stdint.h>
+		R"123(
+#if defined(__TINYC__) && defined(RISCV_PLATFORM_FREEBSD)
+#define int8_t   char
+#define uint8_t  unsigned char
+#define int16_t  short
+#define uint16_t unsigned short
+#define int32_t  int
+#define uint32_t unsigned int
+#define int64_t  long long
+#define uint64_t unsigned long long
+#define uintptr_t unsigned long long
+#else
+#include <stdint.h>
+#endif
 #define LIKELY(x) __builtin_expect((x), 1)
 #define UNLIKELY(x) __builtin_expect((x), 0)
 #define ILLEGAL_OPCODE  0

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -86,6 +86,17 @@ static std::unordered_map<std::string, std::string> create_defines_for(const Mac
 	}
 
 	std::unordered_map<std::string, std::string> defines;
+#if defined(__linux__)
+	defines.emplace("RISCV_PLATFORM_LINUX", "1");
+#elif defined(__APPLE__)
+	defines.emplace("RISCV_PLATFORM_DARWIN", "1");
+#elif defined(_WIN32)
+	defines.emplace("RISCV_PLATFORM_WINDOWS", "1");
+#elif defined(__FreeBSD__)
+	defines.emplace("RISCV_PLATFORM_FREEBSD", "1");
+#elif defined(__OpenBSD__)
+	defines.emplace("RISCV_PLATFORM_OPENBSD", "1");
+#endif
 	defines.emplace("RISCV_TRANSLATION_DYLIB", std::to_string(W));
 	defines.emplace("RISCV_MAX_SYSCALLS", std::to_string(RISCV_SYSCALLS_MAX));
 	defines.emplace("RISCV_ARENA_END", std::to_string(arena_end));


### PR DESCRIPTION
Fix some build issues and testing in a FreeBSD VM.

```
 The *best* time for each kernel (excluding the first iteration)
 will be used to compute the reported bandwidth.
-------------------------------------------------------------
Your clock granularity/precision appears to be 1 microseconds.
Each test below will take on the order of 10433 microseconds.
   (= 10433 clock ticks)
Increase the size of the arrays if this shows that
you are not getting at least 20 clock ticks per test.
-------------------------------------------------------------
WARNING -- The above is only a rough guideline.
For best results, please be sure you know the
precision of your system timer.
-------------------------------------------------------------
Function    Best Rate MB/s  Avg time     Min time     Max time
Copy:           18062.8     0.009008     0.008858     0.009825
Scale:          14907.3     0.012097     0.010733     0.021894
Add:            17429.2     0.013993     0.013770     0.014719
Triad:          10858.7     0.022711     0.022102     0.024903
-------------------------------------------------------------
Solution Validates: avg error less than 1.000000e-13 on all three arrays
-------------------------------------------------------------
>>> Program exited, exit code = 0 (0x0)
Runtime: 1394.979ms   (Use --accurate for instruction counting)
Pages in use: 110 (440 kB virtual memory, total 1768 kB)
```

libtcc "works" but it's clearly not very well supported. No libtcc is installed in the system, only tcc exists as a package.
