### PR TITLE
Allow using libtcc and full binary translation at the same time

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -136,12 +136,13 @@ if (RISCV_BINARY_TRANSLATION)
 		libriscv/tr_emit.cpp
 		libriscv/tr_translate.cpp
 	)
-	if (RISCV_LIBTCC)
-		list(APPEND SOURCES libriscv/tr_tcc.cpp)
-	elseif (MSVC)
+	if (MSVC)
 		list(APPEND SOURCES libriscv/win32/tr_msvc.cpp)
 	else()
 		list(APPEND SOURCES libriscv/tr_compiler.cpp)
+		if (RISCV_LIBTCC)
+			list(APPEND SOURCES libriscv/tr_tcc.cpp)
+		endif()
 	endif()
 endif()
 

--- a/lib/libriscv/cpu.hpp
+++ b/lib/libriscv/cpu.hpp
@@ -182,8 +182,8 @@ namespace riscv
 
 #ifdef RISCV_BINARY_TRANSLATION
 		std::vector<TransMapping<W>> emit(std::string& code, const TransInfo<W>&) const;
-		void activate_dylib(const MachineOptions<W>&, DecodedExecuteSegment<W>&, void*) const RISCV_INTERNAL;
-		bool initialize_translated_segment(DecodedExecuteSegment<W>&, void*) const RISCV_INTERNAL;
+		void activate_dylib(const MachineOptions<W>&, DecodedExecuteSegment<W>&, void*, bool) const RISCV_INTERNAL;
+		bool initialize_translated_segment(DecodedExecuteSegment<W>&, void*, bool) const RISCV_INTERNAL;
 #endif
 		static_assert((W == 4 || W == 8 || W == 16), "Must be either 32-bit, 64-bit or 128-bit ISA");
 	};

--- a/lib/libriscv/decoded_exec_segment.hpp
+++ b/lib/libriscv/decoded_exec_segment.hpp
@@ -60,8 +60,9 @@ namespace riscv
 
 #ifdef RISCV_BINARY_TRANSLATION
 		bool is_binary_translated() const noexcept { return !m_translator_mappings.empty(); }
+		bool is_libtcc() const noexcept { return m_is_libtcc; }
 		void* binary_translation_so() const { return m_bintr_dl; }
-		void set_binary_translated(void* dl) const { m_bintr_dl = dl; }
+		void set_binary_translated(void* dl, bool is_libtcc) const { m_bintr_dl = dl; m_is_libtcc = is_libtcc; }
 		uint32_t translation_hash() const { return m_bintr_hash; }
 		void set_translation_hash(uint32_t hash) { m_bintr_hash = hash; }
 		void reserve_mappings(size_t mappings) { m_translator_mappings.reserve(mappings); }
@@ -101,6 +102,9 @@ namespace riscv
 #endif
 		uint32_t m_crc32c_hash = 0x0; // CRC32-C of the execute segment
 		bool m_is_execute_only = false;
+#ifdef RISCV_BINARY_TRANSLATION
+		mutable bool m_is_libtcc = false;
+#endif
 	};
 
 	template <int W>
@@ -140,9 +144,9 @@ namespace riscv
 	inline DecodedExecuteSegment<W>::~DecodedExecuteSegment()
 	{
 #ifdef RISCV_BINARY_TRANSLATION
-		extern void  dylib_close(void* dylib);
+		extern void  dylib_close(void* dylib, bool is_libtcc);
 		if (m_bintr_dl)
-			dylib_close(m_bintr_dl);
+			dylib_close(m_bintr_dl, m_is_libtcc);
 #endif
 	}
 

--- a/lib/libriscv/tr_compiler.cpp
+++ b/lib/libriscv/tr_compiler.cpp
@@ -160,13 +160,27 @@ namespace riscv
 		return true;
 	}
 
-	void* dylib_lookup(void* dylib, const char* symbol)
+	extern void  tcc_close(void* state);
+	extern void* tcc_lookup(void* state, const char*);
+
+	void* dylib_lookup(void* dylib, const char* symbol, bool is_libtcc)
 	{
+#ifdef RISCV_LIBTCC
+		if (is_libtcc) {
+			return tcc_lookup(dylib, symbol);
+		}
+#endif
 		return dlsym(dylib, symbol);
 	}
 
-	void dylib_close(void* dylib)
+	void dylib_close(void* dylib, bool is_libtcc)
 	{
+#ifdef RISCV_LIBTCC
+		if (is_libtcc) {
+			tcc_close(dylib);
+			return;
+		}
+#endif
 		dlclose(dylib);
 	}
 }

--- a/lib/libriscv/tr_tcc.cpp
+++ b/lib/libriscv/tr_tcc.cpp
@@ -55,12 +55,12 @@ namespace riscv
 		return state;
 	}
 
-	void* dylib_lookup(void* state, const char* symbol)
+	void* tcc_lookup(void* state, const char* symbol)
 	{
 		return tcc_get_symbol((TCCState *)state, symbol);
 	}
 
-	void dylib_close(void* state)
+	void tcc_close(void* state)
 	{
 		tcc_delete((TCCState *)state);
 	}

--- a/lib/libriscv/win32/tr_msvc.cpp
+++ b/lib/libriscv/win32/tr_msvc.cpp
@@ -15,12 +15,12 @@ namespace riscv
 		return nullptr;
 	}
 
-	void* dylib_lookup(void* dylib, const char* symbol)
+	void* dylib_lookup(void* dylib, const char* symbol, bool)
 	{
 		return dlsym(dylib, symbol);
 	}
 
-	void dylib_close(void* dylib)
+	void dylib_close(void* dylib, bool)
 	{
 		dlclose(dylib);
 	}


### PR DESCRIPTION
With this PR it is now possible to:
1. Provide full binary translation via embedded code, or...
2. Load full binary translation from shared object, or...
3. JIT-compile using libtcc as last resort

This unifies all 3 translation methods, paving the way for all of them to be default-enabled at some point.
It also enables producing full binary translation in the background, although I'm not sure if I would use it.
