### PR TITLE
Implement binary translation background compilation feature

### DIFF
--- a/emulator/src/main.cpp
+++ b/emulator/src/main.cpp
@@ -3,6 +3,7 @@
 #include <libriscv/rsp_server.hpp>
 #include <inttypes.h>
 #include <chrono>
+#include <thread>
 #include "settings.hpp"
 static inline std::vector<uint8_t> load_file(const std::string&);
 static constexpr uint64_t MAX_MEMORY = 2000ULL << 20;
@@ -219,6 +220,12 @@ static void run_program(
 		.translation_prefix = "translations/rvbintr-",
 		.translation_suffix = ".dll",
 #else
+		.translate_background_callback =
+			[] (auto& compilation_step) {
+				std::thread([compilation_step = std::move(compilation_step)] {
+					compilation_step();
+				}).detach();
+			},
 		.cross_compile = cc,
 #endif
 #endif

--- a/lib/libriscv/common.hpp
+++ b/lib/libriscv/common.hpp
@@ -173,15 +173,11 @@ namespace riscv
 		unsigned translate_instr_max = 250'000;
 		/// @brief Enable background compilation of shared objects. The compilation step
 		/// will be executed from a user-provided callback, and will be applied to the machine
-		/// when ready. Applying the translation is thread-safe. Enabling this option will make
-		/// the shared execute segment become referenced by the background compilation step,
-		/// keeping it alive until the compilation is done. For short-lived programs, this
-		/// should be disabled.
-		/// @details Throws an exception if shared execute segments are disabled. The user-provided
-		/// callback receives a callback function that is the compilation step. The point of the
-		/// callback is to allow the user to compile the shared object in a separate thread or process.
-		/// Once the callback is done, if the compilation was successful, it will automatically apply.
-		std::function<void(std::function<void()>&)> translate_background_callback = nullptr;
+		/// when ready. Applying the translation is thread-safe and will take effect on all
+		/// machines using the translated execute segment, even while they are executing.
+		/// For short-lived programs, this feature should be disabled, as it often takes more
+		/// time to translate and compile than to execute the program.
+		std::function<void(std::function<void()>& compilation_step)> translate_background_callback = nullptr;
 		/// @brief Allow the production of a secondary dependency-free DLL that can be
 		/// transferred to and loaded on Windows (or other) machines. It will be used
 		/// to greatly accelerate the emulation of the RISC-V program.

--- a/lib/libriscv/common.hpp
+++ b/lib/libriscv/common.hpp
@@ -170,7 +170,18 @@ namespace riscv
 		/// @details The binary translator will stop translating after reaching
 		/// either of these limits. The limits are per shared object.
 		unsigned translate_blocks_max = 16'000;
-		unsigned translate_instr_max = 150'000;
+		unsigned translate_instr_max = 250'000;
+		/// @brief Enable background compilation of shared objects. The compilation step
+		/// will be executed from a user-provided callback, and will be applied to the machine
+		/// when ready. Applying the translation is thread-safe. Enabling this option will make
+		/// the shared execute segment become referenced by the background compilation step,
+		/// keeping it alive until the compilation is done. For short-lived programs, this
+		/// should be disabled.
+		/// @details Throws an exception if shared execute segments are disabled. The user-provided
+		/// callback receives a callback function that is the compilation step. The point of the
+		/// callback is to allow the user to compile the shared object in a separate thread or process.
+		/// Once the callback is done, if the compilation was successful, it will automatically apply.
+		std::function<void(std::function<void()>&)> translate_background_callback = nullptr;
 		/// @brief Allow the production of a secondary dependency-free DLL that can be
 		/// transferred to and loaded on Windows (or other) machines. It will be used
 		/// to greatly accelerate the emulation of the RISC-V program.

--- a/lib/libriscv/cpu.hpp
+++ b/lib/libriscv/cpu.hpp
@@ -182,7 +182,7 @@ namespace riscv
 
 #ifdef RISCV_BINARY_TRANSLATION
 		std::vector<TransMapping<W>> emit(std::string& code, const TransInfo<W>&) const;
-		void activate_dylib(const MachineOptions<W>&, DecodedExecuteSegment<W>&, void*, bool) const RISCV_INTERNAL;
+		void activate_dylib(const MachineOptions<W>&, DecodedExecuteSegment<W>&, void*, bool, bool) const RISCV_INTERNAL;
 		bool initialize_translated_segment(DecodedExecuteSegment<W>&, void*, bool) const RISCV_INTERNAL;
 #endif
 		static_assert((W == 4 || W == 8 || W == 16), "Must be either 32-bit, 64-bit or 128-bit ISA");

--- a/lib/libriscv/cpu.hpp
+++ b/lib/libriscv/cpu.hpp
@@ -117,7 +117,7 @@ namespace riscv
 
 		// Binary translation functions
 		int  load_translation(const MachineOptions<W>&, std::string* filename, DecodedExecuteSegment<W>&) const;
-		void try_translate(const MachineOptions<W>&, const std::string&, DecodedExecuteSegment<W>&, address_t pc, address_t endpc) const;
+		void try_translate(const MachineOptions<W>&, const std::string&, std::shared_ptr<DecodedExecuteSegment<W>>&, address_t pc, address_t endpc) const;
 
 		void reset();
 		void reset_stack_pointer() noexcept;
@@ -182,8 +182,8 @@ namespace riscv
 
 #ifdef RISCV_BINARY_TRANSLATION
 		std::vector<TransMapping<W>> emit(std::string& code, const TransInfo<W>&) const;
-		void activate_dylib(const MachineOptions<W>&, DecodedExecuteSegment<W>&, void*, bool, bool) const RISCV_INTERNAL;
-		bool initialize_translated_segment(DecodedExecuteSegment<W>&, void*, bool) const RISCV_INTERNAL;
+		static void activate_dylib(const MachineOptions<W>&, DecodedExecuteSegment<W>&, void*, void*, bool, bool) RISCV_INTERNAL;
+		static bool initialize_translated_segment(DecodedExecuteSegment<W>&, void*, void*, bool) RISCV_INTERNAL;
 #endif
 		static_assert((W == 4 || W == 8 || W == 16), "Must be either 32-bit, 64-bit or 128-bit ISA");
 	};

--- a/lib/libriscv/decoded_exec_segment.hpp
+++ b/lib/libriscv/decoded_exec_segment.hpp
@@ -65,8 +65,8 @@ namespace riscv
 		void set_binary_translated(void* dl, bool is_libtcc) const { m_bintr_dl = dl; m_is_libtcc = is_libtcc; }
 		uint32_t translation_hash() const { return m_bintr_hash; }
 		void set_translation_hash(uint32_t hash) { m_bintr_hash = hash; }
-		void reserve_mappings(size_t mappings) { m_translator_mappings.reserve(mappings); }
-		void add_mapping(bintr_block_func<W> handler) { m_translator_mappings.push_back(handler); }
+		void create_mappings(size_t mappings) { m_translator_mappings.resize(mappings); }
+		void set_mapping(unsigned i, bintr_block_func<W> handler) { m_translator_mappings.at(i) = handler; }
 		bintr_block_func<W> mapping_at(unsigned i) const { return m_translator_mappings.at(i); }
 		bintr_block_func<W> unchecked_mapping_at(unsigned i) const { return m_translator_mappings[i]; }
 		size_t translator_mappings() const noexcept { return m_translator_mappings.size(); }

--- a/lib/libriscv/decoder_cache.cpp
+++ b/lib/libriscv/decoder_cache.cpp
@@ -267,8 +267,9 @@ namespace riscv
 	template <int W> RISCV_INTERNAL
 	void Memory<W>::generate_decoder_cache(
 		[[maybe_unused]] const MachineOptions<W>& options,
-		DecodedExecuteSegment<W>& exec)
+		std::shared_ptr<DecodedExecuteSegment<W>>& shared_segment)
 	{
+		auto& exec = *shared_segment;
 		if (exec.exec_end() < exec.exec_begin())
 			throw MachineException(INVALID_PROGRAM, "Execute segment was invalid");
 
@@ -320,7 +321,7 @@ namespace riscv
 			if (must_translate)
 			{
 				machine().cpu.try_translate(
-					options, bintr_filename, exec, addr, addr + len);
+					options, bintr_filename, shared_segment, addr, addr + len);
 			}
 		} // W != 16
 	#endif
@@ -504,7 +505,7 @@ namespace riscv
 			// Store the hash in the decoder cache
 			free_slot->set_crc32c_hash(hash);
 
-			this->generate_decoder_cache(options, *free_slot);
+			this->generate_decoder_cache(options, free_slot);
 
 			// Share the execute segment
 			shared_execute_segments<W>.get_segment(hash).unlocked_set(free_slot);
@@ -515,7 +516,7 @@ namespace riscv
 			// Store the hash in the decoder cache
 			free_slot->set_crc32c_hash(hash);
 
-			this->generate_decoder_cache(options, *free_slot);
+			this->generate_decoder_cache(options, free_slot);
 		}
 
 		return *free_slot;

--- a/lib/libriscv/decoder_cache.hpp
+++ b/lib/libriscv/decoder_cache.hpp
@@ -65,6 +65,11 @@ struct DecoderData {
 	static Handler* get_handlers() noexcept {
 		return &instr_handlers[0];
 	}
+
+	void atomic_overwrite(const DecoderData<W>& other) noexcept {
+		static_assert(sizeof(DecoderData<W>) == 8, "DecoderData size mismatch");
+		*(uint64_t*)this = *(uint64_t*)&other;
+	}
 private:
 	static inline std::array<Handler, 256> instr_handlers;
 	static inline std::size_t handler_count = 0;

--- a/lib/libriscv/memory.hpp
+++ b/lib/libriscv/memory.hpp
@@ -240,7 +240,7 @@ namespace riscv
 		void binary_loader(const MachineOptions<W>&);
 		void binary_load_ph(const MachineOptions<W>&, const typename Elf::ProgramHeader*, address_t vaddr);
 		void serialize_execute_segment(const MachineOptions<W>&, const typename Elf::ProgramHeader*, address_t vaddr);
-		void generate_decoder_cache(const MachineOptions<W>&, DecodedExecuteSegment<W>&);
+		void generate_decoder_cache(const MachineOptions<W>&, std::shared_ptr<DecodedExecuteSegment<W>>&);
 		// Machine copy-on-write fork
 		void machine_loader(const Machine<W>&, const MachineOptions<W>&);
 


### PR DESCRIPTION
- A new callback can be set where you (the user) receives an opaque function that performs the compilation step
- Once the compilation completes, the results are hot-patched into the execute segment
- Most programs complete before libtcc has a chance to compile the programs, only benchmarks work :) 

In the future, perhaps:
Apply libtcc async, then later apply full binary translation async
