### PR TITLE
v8: Avoid caching execute segments that are likely JIT

### DIFF
--- a/lib/libriscv/decoded_exec_segment.hpp
+++ b/lib/libriscv/decoded_exec_segment.hpp
@@ -82,6 +82,9 @@ namespace riscv
 		bool is_execute_only() const noexcept { return m_is_execute_only; }
 		void set_execute_only(bool is_xo) { m_is_execute_only = is_xo; }
 
+		bool is_likely_jit() const noexcept { return m_is_likely_jit; }
+		void set_likely_jit(bool is_jit) { m_is_likely_jit = is_jit; }
+
 	private:
 		address_t m_vaddr_begin = 0;
 		address_t m_vaddr_end   = 0;
@@ -111,6 +114,9 @@ namespace riscv
 #ifdef RISCV_BINARY_TRANSLATION
 		mutable bool m_is_libtcc = false;
 #endif
+		// High-memory execute segments are likely to be JIT'd, and needs to
+		// be nuked when attempting to re-use the segment
+		bool m_is_likely_jit = false;
 	};
 
 	template <int W>

--- a/lib/libriscv/memory.hpp
+++ b/lib/libriscv/memory.hpp
@@ -180,6 +180,7 @@ namespace riscv
 		size_t cached_execute_segments() const noexcept { return m_exec_segs; }
 		// Evict all execute segments, also disabling the main execute segment
 		void evict_execute_segments();
+		void evict_execute_segment(DecodedExecuteSegment<W>&);
 
 		const auto& binary() const noexcept { return m_binary; }
 		void reset();

--- a/lib/libriscv/threads.hpp
+++ b/lib/libriscv/threads.hpp
@@ -197,11 +197,15 @@ template <int W>
 inline void MultiThreading<W>::wakeup_next()
 {
 	// resume a waiting thread
-	assert(!m_suspended.empty());
-	auto* next = m_suspended.front();
-	m_suspended.erase(m_suspended.begin());
-	// resume next thread
-	next->resume();
+	if (!m_suspended.empty()) {
+		auto* next = m_suspended.front();
+		m_suspended.erase(m_suspended.begin());
+		// resume next thread
+		next->resume();
+	} else {
+		auto* next = get_thread(0);
+		next->resume();
+	}
 }
 
 template <int W>


### PR DESCRIPTION
Also, evict them after switching and avoid binary translating them

This allows running v8 programs with Isolates, JIT-compilation and WebAssembly modules
