### PR TITLE
bintr: Optimize JUMP_TO and returning from JAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Non goals:
 
 ## Benchmarks
 
-[STREAM benchmark](https://gist.github.com/fwsGonzo/a594727a9429cb29f2012652ad43fb37) [CoreMark: 37297](https://gist.github.com/fwsGonzo/7ef100ba4fe7116e97ddb20cf26e6879) vs 41382 native (~90%).
+[STREAM benchmark](https://gist.github.com/fwsGonzo/a594727a9429cb29f2012652ad43fb37) [CoreMark: 38223](https://gist.github.com/fwsGonzo/7ef100ba4fe7116e97ddb20cf26e6879) vs 41382 native (~92%).
 
 Run [D00M 1 in libriscv](/examples/doom) and see for yourself. It should use around 8% CPU at 60 fps.
 

--- a/lib/libriscv/tr_api.cpp
+++ b/lib/libriscv/tr_api.cpp
@@ -199,8 +199,8 @@ static inline int do_syscall(CPU* cpu, uint64_t counter, uint64_t max_counter, a
 #endif
 }
 
-#define JUMP_TO(cpu, addr) \
-	cpu->pc = addr & ~(addr_t)RISCV_ALIGN_MASK;
+#define JUMP_TO(addr) \
+	pc = addr & ~(addr_t)RISCV_ALIGN_MASK;
 
 // https://stackoverflow.com/questions/28868367/getting-the-high-part-of-64-bit-integer-multiplication
 // As written by catid


### PR DESCRIPTION
Returning from a call now covers the whole block, which is a marginal improvement. CoreMark now reaches 92% of native. Safe sandboxing with instruction counting reaches 81% of native.