### PR TITLE
Add EBREAK live-patching support, execute JIT-segments undecoded

### DIFF
--- a/lib/libriscv/common.hpp
+++ b/lib/libriscv/common.hpp
@@ -129,6 +129,10 @@ namespace riscv
 		/// @brief Provide a custom page-fault handler at construction.
 		riscv::Function<struct Page&(Memory<W>&, address_type<W>, bool)> page_fault_handler = nullptr;
 
+		/// @brief Call ebreak for each of the addresses in the vector.
+		/// @details This is useful for debugging and live-patching programs.
+		std::vector<std::variant<address_type<W>, std::string>> ebreak_locations {};
+
 #ifdef RISCV_BINARY_TRANSLATION
 		/// @brief Enable the binary translator.
 		bool translate_enabled = true;

--- a/lib/libriscv/cpu.hpp
+++ b/lib/libriscv/cpu.hpp
@@ -42,11 +42,15 @@ namespace riscv
 		void simulate_inaccurate(address_t pc);
 
 		// Step precisely one instruction forward from current PC.
-		void step_one();
+		void step_one(bool use_instruction_counter = true);
 
-		// Executes one instruction at a time, and can stop at
+		/// @brief Executes one instruction at a time, and can stop at
 		// any instruction. Can be used for debugging.
 		void simulate_precise();
+
+		/// @brief Executes one instruction at a time, until the execute
+		/// segment is left. Used to execute JIT-compiled code.
+		void simulate_precise_single_segment(const uint8_t* exec_seg, address_t begin_pc, address_t end_pc, address_t pc);
 
 		/// @brief  Get the current PC
 		/// @return The current PC address
@@ -136,6 +140,10 @@ namespace riscv
 		NextExecuteReturn next_execute_segment(address_t pc);
 		static std::shared_ptr<DecodedExecuteSegment<W>>& empty_execute_segment() noexcept;
 		bool is_executable(address_t addr) const noexcept;
+
+		//-- Debugging functions --//
+		/// @brief Install a breakpoint at a specific address, returning the old instruction
+		uint32_t install_ebreak_at(address_t addr);
 
 		// Override the function that gets called when the CPU
 		// throws an execute space protection fault.

--- a/lib/libriscv/cpu_dispatch.cpp
+++ b/lib/libriscv/cpu_dispatch.cpp
@@ -150,7 +150,12 @@ INSTRUCTION(RV32I_BC_SYSTEM, rv32i_system) {
 	// Invoke SYSTEM
 	MACHINE().system(instr);
 	// Restore counters
-	counter.retrieve_max_counter(MACHINE());
+	counter.retrieve_counters(MACHINE());
+	if (UNLIKELY(counter.overflowed() || pc != REGISTERS().pc))
+	{
+		pc = REGISTERS().pc;
+		goto check_jump;
+	}
 	// Overflow-check, next block
 	NEXT_BLOCK(4, true);
 }
@@ -198,7 +203,7 @@ INSTRUCTION(RV32I_BC_SYSCALL, rv32i_syscall) {
 	counter.apply(MACHINE());
 	// Invoke system call
 	MACHINE().system_call(REG(REG_ECALL));
-	// Restore max counter
+	// Restore counters
 	counter.retrieve_counters(MACHINE());
 	if (UNLIKELY(counter.overflowed() || pc != REGISTERS().pc))
 	{

--- a/lib/libriscv/cpu_inaccurate_dispatch.cpp
+++ b/lib/libriscv/cpu_inaccurate_dispatch.cpp
@@ -143,6 +143,12 @@ INSTRUCTION(RV32I_BC_SYSTEM, rv32i_system)
 	REGISTERS().pc = pc;
 	// Invoke SYSTEM
 	MACHINE().system(instr);
+	// Check if we need to jump
+	if (UNLIKELY(pc != REGISTERS().pc))
+	{
+		pc = REGISTERS().pc;
+		goto check_jump;
+	}
 	// Overflow-check, next block
 	NEXT_BLOCK(4, true);
 }

--- a/lib/libriscv/linux/system_calls.cpp
+++ b/lib/libriscv/linux/system_calls.cpp
@@ -1196,6 +1196,8 @@ void Machine<W>::setup_linux_syscalls(bool filesystem, bool sockets)
 	// clock_gettime
 	install_syscall_handler(113, syscall_clock_gettime<W>);
 	install_syscall_handler(403, syscall_clock_gettime64<W>);
+	// clock_getres
+	install_syscall_handler(114, syscall_stub_nosys<W>);
 	// clock_nanosleep
 	install_syscall_handler(115, syscall_clock_nanosleep<W>);
 	// sched_getaffinity

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -414,6 +414,22 @@ if constexpr (SCAN_FOR_GP) {
 	}
 } // SCAN_FOR_GP
 
+	// EBREAK locations
+	std::unordered_set<address_type<W>> ebreak_locations;
+	for (auto& loc : options.ebreak_locations) {
+		address_t addr = 0;
+		if (std::holds_alternative<address_type<W>>(loc))
+			addr = std::get<address_type<W>>(loc);
+		else
+			addr = machine().address_of(std::get<std::string>(loc));
+		if (addr != 0x0) {
+			ebreak_locations.insert(addr);
+			if (verbose) {
+				printf("libriscv: Added ebreak location at 0x%lX\n", (long)addr);
+			}
+		}
+	}
+
 	// Code block and loop detection
 	TIME_POINT(t2);
 	static constexpr size_t ITS_TIME_TO_SPLIT = 1'250;
@@ -542,6 +558,7 @@ if constexpr (SCAN_FOR_GP) {
 				options.use_shared_execute_segments,
 				std::move(jump_locations),
 				nullptr, // blocks
+				&ebreak_locations,
 				global_jump_locations,
 				(uintptr_t)machine().memory.memory_arena_ptr_ref()
 			});

--- a/lib/libriscv/tr_types.hpp
+++ b/lib/libriscv/tr_types.hpp
@@ -23,6 +23,8 @@ namespace riscv
 		std::unordered_set<address_type<W>> jump_locations;
 		// Pointer to all the other blocks (including current)
 		std::vector<TransInfo<W>>* blocks = nullptr;
+		// Pointer to list of ebreak-locations
+		const std::unordered_set<address_type<W>>* ebreak_locations = nullptr;
 
 		std::unordered_set<address_type<W>>& global_jump_locations;
 


### PR DESCRIPTION
This allows running NodeJS to start 2x faster, and allows using faster decoding for main segment

At some point the decoder cache should set up traps so that changes to the execute segment cause it to be come stale and eventually evicted automatically. For now, JIT-segments will just be executed slowly.

```
$ time ./rvlinux -P ../binaries/node -- --jitless test.js
Warning: disabling flag --expose_wasm due to conflicting flags
Node.js says fibonacci(10) = 55
>>> Program exited, exit code = 0 (0x0)
Runtime: 926.901ms   (Use --accurate for instruction counting)
Pages in use: 9317 (37268 kB virtual memory, total 56127 kB)

real	0m1,106s
user	0m1,038s
sys	0m0,056s
$ time ./rvlinux -P ../binaries/node -- test.js
Node.js says fibonacci(10) = 55
>>> Program exited, exit code = 0 (0x0)
Runtime: 1262.357ms   (Use --accurate for instruction counting)
Pages in use: 9317 (37268 kB virtual memory, total 56127 kB)

real	0m1,442s
user	0m1,378s
sys	0m0,052s
```

`--jitless` has much faster overall execution.
