### PR TITLE
Use instruction handler caching for JIT-segments

### DIFF
--- a/lib/libriscv/cpu.hpp
+++ b/lib/libriscv/cpu.hpp
@@ -192,6 +192,7 @@ namespace riscv
 			address_t basepc = 0;
 			address_t endpc  = 0;
 			const uint8_t* area = nullptr;
+			std::unique_ptr<instruction_handler<W>[]> handlers = nullptr;
 		};
 		JitArea m_jit_area;
 


### PR DESCRIPTION
Even though it's not fast, it's ~10-30% faster than not doing it

To really speed up JIT-segments we need a new dispatch the produces fast bytecodes on-demand. But it's a lot of effort for ~little gain.
