### PR TITLE
Just-in-time evict and reprocess JIT-segments

### DIFF
--- a/lib/libriscv/cpu.hpp
+++ b/lib/libriscv/cpu.hpp
@@ -48,10 +48,6 @@ namespace riscv
 		// any instruction. Can be used for debugging.
 		void simulate_precise();
 
-		/// @brief Executes one instruction at a time, until the execute
-		/// segment is left. Used to execute JIT-compiled code.
-		address_t simulate_precise_single_segment(const uint8_t* exec_seg, address_t begin_pc, address_t end_pc, address_t pc);
-
 		/// @brief  Get the current PC
 		/// @return The current PC address
 		address_t pc() const noexcept { return registers().pc; }
@@ -129,7 +125,7 @@ namespace riscv
 		CPU(Machine<W>&, unsigned cpu_id);
 		CPU(Machine<W>&, unsigned cpu_id, const Machine<W>& other); // Fork
 
-		DecodedExecuteSegment<W>& init_execute_area(const void* data, address_t begin, address_t length);
+		DecodedExecuteSegment<W>& init_execute_area(const void* data, address_t begin, address_t length, bool is_likely_jit = false);
 		void set_execute_segment(DecodedExecuteSegment<W>& seg) noexcept { m_exec = &seg; }
 		auto& current_execute_segment() noexcept { return *m_exec; }
 		auto& current_execute_segment() const noexcept { return *m_exec; }
@@ -187,14 +183,6 @@ namespace riscv
 		override_execute_segment_t m_override_exec = [] (auto&) -> DecodedExecuteSegment<W>& {
 			return *empty_execute_segment();
 		};
-
-		struct JitArea {
-			address_t basepc = 0;
-			address_t endpc  = 0;
-			const uint8_t* area = nullptr;
-			std::unique_ptr<instruction_handler<W>[]> handlers = nullptr;
-		};
-		JitArea m_jit_area;
 
 #ifdef RISCV_BINARY_TRANSLATION
 		std::vector<TransMapping<W>> emit(std::string& code, const TransInfo<W>&) const;

--- a/lib/libriscv/cpu_inaccurate_dispatch.cpp
+++ b/lib/libriscv/cpu_inaccurate_dispatch.cpp
@@ -250,6 +250,13 @@ INSTRUCTION(RV32I_BC_STOP, rv32i_stop)
 	execute_invalid:
 		// Calculate the current PC from the decoder pointer
 		pc = (decoder - exec_decoder) << DecoderCache<W>::SHIFT;
+		// Check if the instruction is still invalid
+		try {
+			if (exec->is_likely_jit() && MACHINE().memory.template read<uint16_t>(pc) != uint16_t(decoder->instr)) {
+				exec->set_stale(true);
+				goto new_execute_segment;
+			}
+		} catch (...) {}
 		registers().pc = pc;
 		trigger_exception(ILLEGAL_OPCODE, decoder->instr);
 

--- a/lib/libriscv/decoded_exec_segment.hpp
+++ b/lib/libriscv/decoded_exec_segment.hpp
@@ -85,6 +85,9 @@ namespace riscv
 		bool is_likely_jit() const noexcept { return m_is_likely_jit; }
 		void set_likely_jit(bool is_jit) { m_is_likely_jit = is_jit; }
 
+		bool is_stale() const noexcept { return m_is_stale; }
+		void set_stale(bool is_stale) { m_is_stale = is_stale; }
+
 	private:
 		address_t m_vaddr_begin = 0;
 		address_t m_vaddr_end   = 0;
@@ -117,6 +120,7 @@ namespace riscv
 		// High-memory execute segments are likely to be JIT'd, and needs to
 		// be nuked when attempting to re-use the segment
 		bool m_is_likely_jit = false;
+		bool m_is_stale = false;
 	};
 
 	template <int W>

--- a/lib/libriscv/decoder_cache.cpp
+++ b/lib/libriscv/decoder_cache.cpp
@@ -573,16 +573,6 @@ namespace riscv
 	}
 
 	template <int W>
-	std::shared_ptr<DecodedExecuteSegment<W>>& Memory<W>::exec_segment_for(address_t vaddr)
-	{
-		for (size_t i = 0; i < m_exec_segs; i++) {
-			auto& segment = m_exec[i];
-			if (segment && segment->is_within(vaddr)) return segment;
-		}
-		return CPU<W>::empty_execute_segment();
-	}
-
-	template <int W>
 	const std::shared_ptr<DecodedExecuteSegment<W>>& Memory<W>::exec_segment_for(address_t vaddr) const
 	{
 		return const_cast<Memory<W>*>(this)->exec_segment_for(vaddr);

--- a/lib/libriscv/memory.hpp
+++ b/lib/libriscv/memory.hpp
@@ -176,7 +176,7 @@ namespace riscv
 		// Custom execute segment, returns page base, final size and execute segment pointer
 		std::shared_ptr<DecodedExecuteSegment<W>>& exec_segment_for(address_t vaddr);
 		const std::shared_ptr<DecodedExecuteSegment<W>>& exec_segment_for(address_t vaddr) const;
-		DecodedExecuteSegment<W>& create_execute_segment(const MachineOptions<W>&, const void* data, address_t addr, size_t len, bool is_initial);
+		DecodedExecuteSegment<W>& create_execute_segment(const MachineOptions<W>&, const void* data, address_t addr, size_t len, bool is_initial, bool is_likely_jit = false);
 		size_t cached_execute_segments() const noexcept { return m_exec_segs; }
 		// Evict all execute segments, also disabling the main execute segment
 		void evict_execute_segments();

--- a/lib/libriscv/memory_inline.hpp
+++ b/lib/libriscv/memory_inline.hpp
@@ -153,3 +153,13 @@ inline void Memory<W>::set_exit_address(address_t addr)
 {
 	this->m_exit_address = addr;
 }
+
+template <int W>
+inline std::shared_ptr<DecodedExecuteSegment<W>>& Memory<W>::exec_segment_for(address_t vaddr)
+{
+	for (size_t i = 0; i < m_exec_segs; i++) {
+		auto& segment = m_exec[i];
+		if (segment && segment->is_within(vaddr)) return segment;
+	}
+	return CPU<W>::empty_execute_segment();
+}


### PR DESCRIPTION
This is the fast-path version of yesterdays work, where JIT segments finally get to use the normal dispatch It also reduces and simplifies the overall code. Deleting slow code feels good.

No benefit has been seen from using libtcc or binary translation, even in the background
I suspect that my test programs are not generating the best possible code either. We'll see.