### PR TITLE
bintr: Add recording and using of slow-path locations to file

### DIFF
--- a/emulator/src/settings.hpp
+++ b/emulator/src/settings.hpp
@@ -1,4 +1,10 @@
 #pragma once
+#include <string>
+#include <unordered_set>
+template <int W>
+static std::vector<riscv::address_type<W>> load_jump_hints(const std::string& filename, bool verbose = false);
+template <int W>
+static void store_jump_hints(const std::string& filename, const std::vector<riscv::address_type<W>>& hints);
 
 #if defined(EMULATOR_MODE_LINUX)
 	static constexpr bool full_linux_guest = true;

--- a/lib/libriscv/common.hpp
+++ b/lib/libriscv/common.hpp
@@ -178,6 +178,10 @@ namespace riscv
 #else
 		bool translate_use_register_caching = false;
 #endif
+		/// @brief Enable recording of slowpaths to jump hints for the binary translator.
+		/// @details This will record slowpaths to the MachineOptions jump hints vector.
+		/// From there the CLI can save the jump hints to a file after the program has run.
+		bool record_slowpaths_to_jump_hints = false;
 		/// @brief Prefix for the translation output file.
 		std::string translation_prefix = "/tmp/rvbintr-";
 		/// @brief Suffix for the translation output file. Eg. .dll or .so
@@ -187,6 +191,9 @@ namespace riscv
 		/// either of these limits. The limits are per shared object.
 		unsigned translate_blocks_max = 1024;
 		unsigned translate_instr_max = 500'000;
+		/// @brief Jump location hints for the binary translator.
+		/// @details These hints can improve performance of the binary translation.
+		std::vector<address_type<W>> translator_jump_hints {};
 		/// @brief Enable background compilation of shared objects. The compilation step
 		/// will be executed from a user-provided callback, and will be applied to the machine
 		/// when ready. Applying the translation is thread-safe and will take effect on all

--- a/lib/libriscv/cpu_inaccurate_dispatch.cpp
+++ b/lib/libriscv/cpu_inaccurate_dispatch.cpp
@@ -164,8 +164,11 @@ retry_translated_function:
 	if (LIKELY(bintr_results.max_counter != 0 && (pc - current_begin < current_end - current_begin)))
 	{
 		decoder = &exec_decoder[pc >> DecoderCache<W>::SHIFT];
-		if (decoder->get_bytecode() == RV32I_BC_TRANSLATOR)
+		if (decoder->get_bytecode() == RV32I_BC_TRANSLATOR) {
 			goto retry_translated_function;
+		}
+		if (exec->is_recording_slowpaths())
+			exec->insert_slowpath_address(pc);
 		goto continue_segment;
 	} else if (bintr_results.max_counter == 0)
 		goto exit_check;

--- a/lib/libriscv/machine.hpp
+++ b/lib/libriscv/machine.hpp
@@ -69,6 +69,7 @@ namespace riscv
 		/// @brief Returns the machine options that were used to create the machine.
 		/// @return The machine options.
 		auto& options() const noexcept { return m_options; }
+		auto& options() noexcept { return m_options; }
 
 		/// @brief Simulate RISC-V starting from the PC register, and
 		/// stopping when at most @max_instructions have been executed.

--- a/lib/libriscv/memory.hpp
+++ b/lib/libriscv/memory.hpp
@@ -181,6 +181,9 @@ namespace riscv
 		// Evict all execute segments, also disabling the main execute segment
 		void evict_execute_segments();
 		void evict_execute_segment(DecodedExecuteSegment<W>&);
+#ifdef RISCV_BINARY_TRANSLATION
+		std::vector<address_t> gather_jump_hints() const;
+#endif
 
 		const auto& binary() const noexcept { return m_binary; }
 		void reset();

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -207,7 +207,7 @@ int CPU<W>::load_translation(const MachineOptions<W>& options,
 		throw MachineException(ILLEGAL_OPERATION, "Execute segment already binary translated");
 	}
 
-	// Checksum the execute segment + compiler flags
+	// Checksum the execute segment, ...
 	TIME_POINT(t5);
 	const std::string cflags = defines_to_string(create_defines_for(machine(), options));
 	extern std::string compile_command(int arch, const std::string& cflags);
@@ -439,6 +439,12 @@ if constexpr (SCAN_FOR_GP) {
 		global_jump_locations.insert(elf_entry);
 	// Speculate that the first instruction is a jump target
 	global_jump_locations.insert(exec.exec_begin());
+
+	for (auto address : options.translator_jump_hints) {
+		if (address >= basepc && address < endbasepc) {
+			global_jump_locations.insert(address);
+		}
+	}
 
 	for (address_t pc = basepc; pc < endbasepc && icounter < options.translate_instr_max; )
 	{


### PR DESCRIPTION
The binary translator sometimes misses jump locations, however we can record and use them in order to understand the impact