### PR TITLE
Add binary translation support to 128-bit RISC-V

### DIFF
--- a/lib/libriscv/decoder_cache.cpp
+++ b/lib/libriscv/decoder_cache.cpp
@@ -316,7 +316,7 @@ namespace riscv
 		// We do not support binary translation for RV128I
 		// Also, avoid binary translation for execute segments that are likely JIT-compiled
 		const bool allow_translation = is_initial || options.translate_future_segments;
-		if (W != 16 && !exec.is_binary_translated() && allow_translation && !exec.is_likely_jit()) {
+		if (!exec.is_binary_translated() && allow_translation && !exec.is_likely_jit()) {
 			// Attempt to load binary translation
 			// Also, fill out the binary translation SO filename for later
 			std::string bintr_filename;
@@ -327,7 +327,7 @@ namespace riscv
 				machine().cpu.try_translate(
 					options, bintr_filename, shared_segment);
 			}
-		} // W != 16
+		}
 	#endif
 
 		// Debugging: EBREAK locations

--- a/lib/libriscv/linux/syscalls_mman.cpp
+++ b/lib/libriscv/linux/syscalls_mman.cpp
@@ -80,7 +80,7 @@ static void add_mman_syscalls()
 #else
 				if (lseek(real_fd, voff, SEEK_SET) == (off_t)-1)
 					MMAP_HAS_FAILED();
-				if (readv(real_fd, (const iovec*)&buffers[0], cnt) != (ssize_t)length)
+				if (readv(real_fd, (const iovec*)&buffers[0], cnt) < 0)
 					MMAP_HAS_FAILED();
 #endif
 				// Set new page protections on area

--- a/lib/libriscv/memory.cpp
+++ b/lib/libriscv/memory.cpp
@@ -428,8 +428,8 @@ namespace riscv
 		}
 
 		if (this->uses_flat_memory_arena() && this->memory_arena_size() >= m_arena.initial_rodata_end) {
-			this->m_arena.read_boundary = std::min(this->memory_arena_size(), this->memory_arena_size() - RWREAD_BEGIN);
-			this->m_arena.write_boundary = std::min(this->memory_arena_size(), this->memory_arena_size() - m_arena.initial_rodata_end);
+			this->m_arena.read_boundary = std::min(this->memory_arena_size(), size_t(this->memory_arena_size() - RWREAD_BEGIN));
+			this->m_arena.write_boundary = std::min(this->memory_arena_size(), size_t(this->memory_arena_size() - m_arena.initial_rodata_end));
 		} else {
 			this->m_arena.initial_rodata_end = 0;
 		}

--- a/lib/libriscv/memory.hpp
+++ b/lib/libriscv/memory.hpp
@@ -193,7 +193,7 @@ namespace riscv
 		bool uses_Nbit_encompassing_arena() const noexcept { return riscv::encompassing_Nbit_arena != 0 && this->m_arena.data != nullptr; }
 		void* memory_arena_ptr() const noexcept { return (void *)this->m_arena.data; }
 		auto& memory_arena_ptr_ref() const noexcept { return this->m_arena.data; }
-		address_t memory_arena_size() const noexcept { return this->m_arena.pages * Page::size(); }
+		size_t memory_arena_size() const noexcept { return this->m_arena.pages * Page::size(); }
 		address_t memory_arena_read_boundary() const noexcept { return this->m_arena.read_boundary; }
 		address_t memory_arena_write_boundary() const noexcept { return this->m_arena.write_boundary; }
 		address_t initial_rodata_end() const noexcept { return this->m_arena.initial_rodata_end; }

--- a/lib/libriscv/memory_rw.cpp
+++ b/lib/libriscv/memory_rw.cpp
@@ -136,7 +136,7 @@ namespace riscv
 						// XXX: doesn't scale on busy server
 						if (offset == 0 && size == Page::size()) {
 							address_t new_dst = dst + (len & ~address_t(Page::size()-1));
-							new_dst = std::min(new_dst, memory_arena_size());
+							new_dst = std::min(new_dst, (address_t)memory_arena_size());
 							const size_t new_size = new_dst - dst;
 
 							auto* baseptr = &((uint8_t *)m_arena.data)[dst];

--- a/lib/libriscv/tr_api.cpp
+++ b/lib/libriscv/tr_api.cpp
@@ -27,10 +27,13 @@ namespace riscv {
 	typedef uint32_t addr_t;
 	typedef int32_t saddr_t;
 #  define XLEN  32
-#else
+#elif RISCV_TRANSLATION_DYLIB == 8
 	typedef uint64_t addr_t;
 	typedef int64_t saddr_t;
 #  define XLEN  64
+#elif RISCV_TRANSLATION_DYLIB == 16
+	typedef __uint128_t addr_t;
+	typedef __int128_t saddr_t;
 #endif
 #ifdef RISCV_EXT_C
 #define RISCV_ALIGN_MASK 0x1

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -13,8 +13,8 @@
 #endif
 
 #define PCRELA(x) ((address_t) (this->pc() + (x)))
-#define PCRELS(x) std::to_string(PCRELA(x)) + "UL"
-#define STRADDR(x) (std::to_string(x) + "UL")
+#define PCRELS(x) hex_address(PCRELA(x)) + "L"
+#define STRADDR(x) (hex_address(x) + "L")
 // Reveal PC on unknown instructions
 #ifdef RISCV_LIBTCC
 // libtcc always runs on the current machine, so we can use the handler index directly
@@ -49,7 +49,7 @@
 	this->reload_all_registers(); \
 	this->untrack_all_gprs();     \
   } else if (m_zero_insn_counter <= 1) \
-    code += "api.exception(cpu, " + STRADDR(this->pc()) + ", ILLEGAL_OPCODE);\n"; \
+    code += "api.exception(cpu, " + hex_address(this->pc()) + ", ILLEGAL_OPCODE);\n"; \
 }
 #define WELL_KNOWN_INSTRUCTION() { \
     code += "{ static int handler_idx = 0;\n"; \
@@ -64,7 +64,7 @@ static const std::string SIGNEXTW = "(saddr_t) (int32_t)";
 static constexpr int ALIGN_MASK = (compressed_enabled) ? 0x1 : 0x3;
 
 static std::string hex_address(uint64_t addr) {
-	char buf[32];
+	char buf[64];
 	if (const int len = snprintf(buf, sizeof(buf), "0x%" PRIx64, uint64_t(addr)); len > 0)
 		return std::string(buf, len);
 	throw MachineException(INVALID_PROGRAM, "Failed to format address");
@@ -72,7 +72,7 @@ static std::string hex_address(uint64_t addr) {
 
 template <int W>
 static std::string funclabel(const std::string& func, uint64_t addr) {
-	char buf[32];
+	char buf[64];
 	if (const int len = snprintf(buf, sizeof(buf), "%s_%" PRIx64, func.c_str(), addr); len > 0)
 		return std::string(buf, len);
 	throw MachineException(INVALID_PROGRAM, "Failed to format function label");
@@ -178,10 +178,13 @@ struct Emitter
 
 	std::string from_reg(int reg) {
 		if (reg == 3 && tinfo.gp != 0)
-			return std::to_string(tinfo.gp) + "UL";
+			return hex_address(tinfo.gp) + "L";
 		else if (reg != 0) {
 			if (gpr_has_known_value(reg)) {
-				return std::to_string(get_gpr_value(reg)) + "UL";
+				if constexpr (W == 16)
+					return hex_address(get_gpr_value(reg)) + "L";
+				else
+					return std::to_string(get_gpr_value(reg)) + "UL";
 			} else if (uses_register_caching()) {
 				load_register(reg);
 				return loaded_regname(reg);
@@ -255,7 +258,7 @@ struct Emitter
 				if (riscv::encompassing_Nbit_arena == 32)
 					return "(" + m_arena_hex_address + " + (uint32_t)(" + address + "))";
 				else
-					return "(" + m_arena_hex_address + " + ((" + address + ") & " + std::to_string(address_t(riscv::encompassing_arena_mask)) + "))";
+					return "(" + m_arena_hex_address + " + ((" + address + ") & " + hex_address(address_t(riscv::encompassing_arena_mask)) + "))";
 			} else {
 				return "(" + m_arena_hex_address + " + " + speculation_safe(address) + ")";
 			}
@@ -263,7 +266,7 @@ struct Emitter
 			if constexpr (riscv::encompassing_Nbit_arena == 32)
 				return "ARENA_AT(cpu, (uint32_t)(" + address + "))";
 			else
-				return "ARENA_AT(cpu, " + address + " & " + std::to_string(address_t(riscv::encompassing_arena_mask)) + ")";
+				return "ARENA_AT(cpu, " + address + " & " + hex_address(address_t(riscv::encompassing_arena_mask)) + ")";
 		} else {
 			return "ARENA_AT(cpu, " + speculation_safe(address) + ")";
 		}
@@ -2026,7 +2029,7 @@ CPU<W>::emit(std::string& code, const TransInfo<W>& tinfo)
 	for (size_t idx = 0; idx < e.get_mappings().size(); idx++) {
 		auto& entry = e.get_mappings().at(idx);
 		const auto label = funclabel<W>(e.get_func(), entry.addr);
-		code += "case " + std::to_string(entry.addr) + ": goto " + label + ";\n";
+		code += "case " + hex_address(entry.addr) + ": goto " + label + ";\n";
 	}
 	code += "default:\n";
 #endif
@@ -2049,5 +2052,8 @@ template std::vector<TransMapping<4>> CPU<4>::emit(std::string&, const TransInfo
 #endif
 #ifdef RISCV_64I
 template std::vector<TransMapping<8>> CPU<8>::emit(std::string&, const TransInfo<8>&);
+#endif
+#ifdef RISCV_128I
+template std::vector<TransMapping<16>> CPU<16>::emit(std::string&, const TransInfo<16>&);
 #endif
 } // riscv

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1143,14 +1143,14 @@ void Emitter<W>::emit()
 				add_code(
 					dst + " = " + src + " | " + from_imm(instr.Itype.signed_imm()) + ";");
 				this->track_gpr_if_known(instr.Itype.rd, instr.Itype.rs1,
-					instr.Itype.signed_imm(), get_potential_gpr_value(instr.Itype.rs1) | instr.Itype.signed_imm());
+					get_potential_gpr_value(instr.Itype.rs1) | instr.Itype.signed_imm());
 				tracked = true;
 				break;
 			case 0x7: // ANDI
 				add_code(
 					dst + " = " + src + " & " + from_imm(instr.Itype.signed_imm()) + ";");
 				this->track_gpr_if_known(instr.Itype.rd, instr.Itype.rs1,
-					instr.Itype.signed_imm(), get_potential_gpr_value(instr.Itype.rs1) & instr.Itype.signed_imm());
+					get_potential_gpr_value(instr.Itype.rs1) & instr.Itype.signed_imm());
 				tracked = true;
 				break;
 			default:

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -138,8 +138,8 @@ static std::unordered_map<std::string, std::string> create_defines_for(const Mac
 	const auto arena_offset = uintptr_t(&machine.memory.memory_arena_ptr_ref()) - uintptr_t(&machine);
 
 	// Some executables are loaded at high-memory addresses, which is outside of the memory arena.
-	auto arena_end          = machine.memory.memory_arena_size();
-	auto initial_rodata_end = machine.memory.initial_rodata_end();
+	size_t arena_end                   = machine.memory.memory_arena_size();
+	address_type<W> initial_rodata_end = machine.memory.initial_rodata_end();
 	if (!options.translation_use_arena) {
 		initial_rodata_end = 0;
 		arena_end = 0x1000;
@@ -159,8 +159,13 @@ static std::unordered_map<std::string, std::string> create_defines_for(const Mac
 #endif
 	defines.emplace("RISCV_TRANSLATION_DYLIB", std::to_string(W));
 	defines.emplace("RISCV_MAX_SYSCALLS", std::to_string(RISCV_SYSCALLS_MAX));
-	defines.emplace("RISCV_ARENA_END", std::to_string(arena_end));
-	defines.emplace("RISCV_ARENA_ROEND", std::to_string(initial_rodata_end));
+	if constexpr (W == 16) {
+		defines.emplace("RISCV_ARENA_END", std::to_string(uint64_t(arena_end)));
+		defines.emplace("RISCV_ARENA_ROEND", std::to_string(uint64_t(initial_rodata_end)));
+	} else {
+		defines.emplace("RISCV_ARENA_END", std::to_string(arena_end));
+		defines.emplace("RISCV_ARENA_ROEND", std::to_string(initial_rodata_end));
+	}
 	defines.emplace("RISCV_INS_COUNTER_OFF", std::to_string(ins_counter_offset));
 	defines.emplace("RISCV_MAX_COUNTER_OFF", std::to_string(max_counter_offset));
 	defines.emplace("RISCV_ARENA_OFF", std::to_string(arena_offset));
@@ -1236,6 +1241,11 @@ std::string MachineOptions<W>::translation_filename(const std::string& prefix, u
 	template void CPU<8>::try_translate(const MachineOptions<8>&, const std::string&, std::shared_ptr<DecodedExecuteSegment<8>>&) const;
 	template int CPU<8>::load_translation(const MachineOptions<8>&, std::string*, DecodedExecuteSegment<8>&) const;
 	template std::string MachineOptions<8>::translation_filename(const std::string&, uint32_t, const std::string&);
+#endif
+#ifdef RISCV_128I
+	template void CPU<16>::try_translate(const MachineOptions<16>&, const std::string&, std::shared_ptr<DecodedExecuteSegment<16>>&) const;
+	template int CPU<16>::load_translation(const MachineOptions<16>&, std::string*, DecodedExecuteSegment<16>&) const;
+	template std::string MachineOptions<16>::translation_filename(const std::string&, uint32_t, const std::string&);
 #endif
 
 	timespec time_now()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -48,10 +48,9 @@ add_unit_test(rvbuffer rvbuffer.cpp)
 add_unit_test(serialize serialize.cpp)
 add_unit_test(vmcall   vmcall.cpp)
 add_unit_test(va_exec  va_execute.cpp)
+add_unit_test(elftest  verify_elf.cpp)
 
 if (NOT RISCV_BINARY_TRANSLATION)
-# Some of these ELFs use C-extension which is not supported
-add_unit_test(elftest  verify_elf.cpp)
 # Unknown issues, to be debugged later
 # Possibly bad (inline) assembly :)
 add_unit_test(mptest   mp_testsuite.cpp)


### PR DESCRIPTION
General address and function labels are truncated to 64-bit (in the binary translator) which may cause interpreter speed for 128-bit programs that reside in high memory
