### PR TITLE
Reduce overall loading times

### DIFF
--- a/lib/libriscv/bytecode_impl.cpp
+++ b/lib/libriscv/bytecode_impl.cpp
@@ -571,9 +571,8 @@ INSTRUCTION(RV32F_BC_FMADD, rv32f_fmadd) {
 
 INSTRUCTION(RV32I_BC_FUNCTION, execute_decoded_function)
 {
-	auto handler = DECODER().get_handler();
 	//printf("Slowpath: 0x%X  (instr: 0x%X)\n", uint32_t(pc), DECODER().instr);
-	handler(CPU(), {DECODER().instr});
+	CPU().execute(DECODER().m_handler, DECODER().instr);
 	NEXT_INSTR();
 }
 
@@ -760,10 +759,8 @@ INSTRUCTION(RV32C_BC_ANDI, rv32c_andi) {
 	NEXT_C_INSTR();
 }
 INSTRUCTION(RV32C_BC_JUMPFUNC, rv32c_jumpfunc) {
-	VIEW_INSTR();
 	REGISTERS().pc = pc;
-	auto handler = DECODER().get_handler();
-	handler(CPU(), instr);
+	CPU().execute(DECODER().m_handler, DECODER().instr);
 	if constexpr (VERBOSE_JUMPS) {
 		fprintf(stderr, "Compressed jump from 0x%lX to 0x%lX\n",
 			long(pc), long(REGISTERS().pc + 2));
@@ -772,9 +769,7 @@ INSTRUCTION(RV32C_BC_JUMPFUNC, rv32c_jumpfunc) {
 	OVERFLOW_CHECKED_JUMP();
 }
 INSTRUCTION(RV32C_BC_FUNCTION, rv32c_func) {
-	VIEW_INSTR();
-	auto handler = DECODER().get_handler();
-	handler(CPU(), instr);
+	CPU().execute(DECODER().m_handler, DECODER().instr);
 	NEXT_C_INSTR();
 }
 #endif

--- a/lib/libriscv/cpu.hpp
+++ b/lib/libriscv/cpu.hpp
@@ -88,6 +88,8 @@ namespace riscv
 
 		// Directly execute an instruction (given bits)
 		void execute(format_t);
+		// Directly execute a function by its handler, or if the handler is 0, resolve the handler then execute
+		void execute(uint8_t& handler_idx, uint32_t instr);
 		// Read the next instruction bits
 		format_t read_next_instruction() const;
 		// Internal preempt() implementation that executes and restores old registers

--- a/lib/libriscv/debug.cpp
+++ b/lib/libriscv/debug.cpp
@@ -486,7 +486,7 @@ void DebugMachine<W>::simulate(std::function<void(DebugMachine<W>&)> callback, u
 			// Retrieve handler directly from the instruction handler cache
 			auto& cache_entry =
 				exec_decoder[pc / DecoderCache<W>::DIVISOR];
-			cache_entry.execute(cpu, instruction);
+			cpu.execute(cache_entry.m_handler, instruction.whole);
 		}
 		else // Not the slowest path, since we have the instruction already
 		{

--- a/lib/libriscv/decoder_cache.hpp
+++ b/lib/libriscv/decoder_cache.hpp
@@ -47,6 +47,12 @@ struct DecoderData {
 	void set_insn_handler(instruction_handler<W> ih) noexcept {
 		this->m_handler = handler_index_for(ih);
 	}
+	void set_invalid_handler() noexcept {
+		this->m_handler = 0;
+	}
+	bool is_invalid_handler() const noexcept {
+		return this->m_handler == 0;
+	}
 
 	RISCV_ALWAYS_INLINE
 	auto block_bytes() const noexcept {
@@ -97,7 +103,7 @@ struct alignas(64) DecoderCache
 		return &cache[0];
 	}
 
-	std::array<DecoderData<W>, PageSize / DIVISOR> cache = {};
+	std::array<DecoderData<W>, PageSize / DIVISOR> cache;
 };
 
 }

--- a/lib/libriscv/rv128i.cpp
+++ b/lib/libriscv/rv128i.cpp
@@ -1,5 +1,7 @@
-#include "rv32i_instr.hpp"
 #include "machine.hpp"
+
+#include "decoder_cache.hpp"
+#include "rv32i_instr.hpp"
 #undef RISCV_EXT_COMPRESSED
 #define RISCV_128BIT_ISA_INSTRUCTIONS
 
@@ -34,6 +36,16 @@ namespace riscv
 #define DECODER(x) { x.handler(*this, instruction); return; }
 #include "instr_decoding.inc"
 #undef DECODER
+	}
+
+	template <> RISCV_INTERNAL
+	void CPU<16>::execute(uint8_t& handler_idx, uint32_t instr)
+	{
+		if (handler_idx == 0 && instr != 0) {
+			[[unlikely]];
+			handler_idx = DecoderData<16>::handler_index_for(decode(instr).handler);
+		}
+		DecoderData<16>::get_handlers()[handler_idx](*this, instr);
 	}
 
 	template <>

--- a/lib/libriscv/rv32i.cpp
+++ b/lib/libriscv/rv32i.cpp
@@ -1,4 +1,6 @@
 #include "machine.hpp"
+
+#include "decoder_cache.hpp"
 #include "rv32i_instr.hpp"
 
 #define INSTRUCTION(x, ...) \
@@ -33,6 +35,16 @@ namespace riscv
 #define DECODER(x) { x.handler(*this, instruction); return; }
 #include "instr_decoding.inc"
 #undef DECODER
+	}
+
+	template <> RISCV_INTERNAL
+	void CPU<4>::execute(uint8_t& handler_idx, uint32_t instr)
+	{
+		if (handler_idx == 0 && instr != 0) {
+			[[unlikely]];
+			handler_idx = DecoderData<4>::handler_index_for(decode(instr).handler);
+		}
+		DecoderData<4>::get_handlers()[handler_idx](*this, instr);
 	}
 
 	template <>

--- a/lib/libriscv/rv64i.cpp
+++ b/lib/libriscv/rv64i.cpp
@@ -1,4 +1,6 @@
 #include "machine.hpp"
+
+#include "decoder_cache.hpp"
 #include "rv32i_instr.hpp"
 
 #define INSTRUCTION(x, ...) \
@@ -33,6 +35,16 @@ namespace riscv
 #define DECODER(x) { x.handler(*this, instruction); return; }
 #include "instr_decoding.inc"
 #undef DECODER
+	}
+
+	template <> RISCV_INTERNAL
+	void CPU<8>::execute(uint8_t& handler_idx, uint32_t instr)
+	{
+		if (handler_idx == 0 && instr != 0) {
+			[[unlikely]];
+			handler_idx = DecoderData<8>::handler_index_for(decode(instr).handler);
+		}
+		DecoderData<8>::get_handlers()[handler_idx](*this, instr);
 	}
 
 	template <>

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -256,8 +256,9 @@ int CPU<W>::load_translation(const MachineOptions<W>& options,
 					const auto& mapping = translation.mappings[i];
 
 					auto& entry = decoder_entry_at(exec.decoder_cache(), mapping.addr);
-					entry.instr = mapping.mapping_index;
 					entry.set_bytecode(bytecode);
+					entry.set_invalid_handler();
+					entry.instr = mapping.mapping_index;
 				}
 				if (options.translate_timing) {
 					TIME_POINT(t7);
@@ -952,6 +953,7 @@ void CPU<W>::activate_dylib(const MachineOptions<W>& options, DecodedExecuteSegm
 					// function, which will be the last instruction in the block.
 					auto& p = decoder_entry_at(patched_decoder, addr);
 					p.set_bytecode(RV32I_BC_TRANSLATOR);
+					p.set_invalid_handler();
 					p.instr  = mapping_index;
 					p.idxend = 0;
 				#ifdef RISCV_EXT_C
@@ -963,8 +965,9 @@ void CPU<W>::activate_dylib(const MachineOptions<W>& options, DecodedExecuteSegm
 					// Normal block-end hint that will be transformed into a translation
 					// bytecode if it passes a few more checks, later.
 					auto& entry = decoder_entry_at(exec.decoder_cache(), addr);
-					entry.instr = mapping_index;
 					entry.set_bytecode(RV32I_BC_TRANSLATOR);
+					entry.set_invalid_handler();
+					entry.instr = mapping_index;
 				}
 			} else {
 				auto& entry = decoder_entry_at(exec.decoder_cache(), addr);


### PR DESCRIPTION
This commit attempts to avoid zeroing the decoder cache, and decodes slow-path instructions only when needed